### PR TITLE
take volumesnapshot of windows image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,3 +109,6 @@ pull-secret.txt
 !*.pub
 credentials.json
 secrets.yaml
+
+# aws
+manifests/windows-vm/accesskey

--- a/manifests/windows-vm/.golden-snapshot.env
+++ b/manifests/windows-vm/.golden-snapshot.env
@@ -1,0 +1,4 @@
+GOLDEN_SNAPSHOT_NAME=windows-golden-snap
+GOLDEN_SNAPSHOT_NS=openshift-virtualization-os-images
+GOLDEN_SC=gp3-csi-immediate-us-east-1b
+GOLDEN_AZ=

--- a/manifests/windows-vm/2_windows-datavolume.yaml
+++ b/manifests/windows-vm/2_windows-datavolume.yaml
@@ -1,0 +1,34 @@
+---
+# Windows 10 DataVolume — Downloads from S3 using static credentials
+#
+# Process:
+# 1. CDI creates an importer pod
+# 2. Pod reads credentials from the s3-credentials Secret
+# 3. Importer downloads from S3 and converts the image
+# 4. Image is stored in a PVC (70Gi)
+# 5. DataSource references this PVC for VM cloning
+#
+# Expected Duration: 5-10 minutes (depends on S3 transfer speed)
+#
+# Monitoring:
+#   oc get datavolume windows -n openshift-virtualization-os-images -w
+#   oc get pods -n openshift-virtualization-os-images
+#
+apiVersion: cdi.kubevirt.io/v1beta1
+kind: DataVolume
+metadata:
+  name: windows
+  namespace: openshift-virtualization-os-images
+spec:
+  contentType: kubevirt
+  source:
+    s3:
+      url: "https://ocpctl-binaries.s3.us-east-1.amazonaws.com/windows-images/windows-10-oadp.qcow2"
+      secretRef: s3-credentials
+  storage:
+    accessModes:
+      - ReadWriteOnce
+    resources:
+      requests:
+        storage: 70Gi
+    storageClassName: gp3-csi-immediate-us-west-2a

--- a/manifests/windows-vm/2_windows-datavolume.yaml
+++ b/manifests/windows-vm/2_windows-datavolume.yaml
@@ -31,4 +31,4 @@ spec:
     resources:
       requests:
         storage: 70Gi
-    storageClassName: gp3-csi-immediate-us-west-2a
+    volumeMode: Block

--- a/manifests/windows-vm/4_windows10-template.yaml
+++ b/manifests/windows-vm/4_windows10-template.yaml
@@ -165,7 +165,7 @@ objects:
             - name: rootdisk
               dataVolume:
                 name: ${VM_NAME}-disk
-
+              volumeMode: Block
 parameters:
   - name: VM_NAME
     description: "Name of the Virtual Machine"
@@ -176,7 +176,4 @@ parameters:
     description: "Namespace to create the VM in"
     value: "default"
     required: true
-  - name: STORAGE_CLASS
-    description: "Storage class for the VM disk"
-    value: "gp3-csi-wfc"
-    required: true
+  # use defaults for sc

--- a/manifests/windows-vm/5_create-golden-snapshot.sh
+++ b/manifests/windows-vm/5_create-golden-snapshot.sh
@@ -1,0 +1,238 @@
+#!/bin/bash
+#
+# 5_create-golden-snapshot.sh - Create a VolumeSnapshot of the Windows golden image
+#
+# Takes a VolumeSnapshot of the 'windows' PVC in openshift-virtualization-os-images.
+# Subsequent VM launches can restore from this snapshot (~2-5 min on EBS) instead of
+# cloning from the DataSource (~30 min per VM).
+#
+# Prerequisites:
+#   - 'windows' DataVolume must be in Succeeded phase (run 2_setup-storageclass.sh first)
+#   - A VolumeSnapshotClass must exist for the cluster's CSI driver
+#
+# Usage:
+#   ./5_create-golden-snapshot.sh [--name <name>] [--snapshot-class <class>] [--dry-run]
+#
+# Examples:
+#   ./5_create-golden-snapshot.sh
+#   ./5_create-golden-snapshot.sh --name my-snap
+#   ./5_create-golden-snapshot.sh --dry-run
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ENV_FILE="${SCRIPT_DIR}/.golden-snapshot.env"
+
+PVC_NAME="windows"
+PVC_NAMESPACE="openshift-virtualization-os-images"
+SNAP_NAME="windows-golden-snap"
+SNAP_CLASS="csi-aws-vsc"
+DRY_RUN=false
+
+die() { echo "[ERROR] $*" >&2; exit 1; }
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --name)
+      [[ $# -ge 2 ]] || die "--name requires a value"
+      SNAP_NAME="$2"; shift 2 ;;
+    --snapshot-class)
+      [[ $# -ge 2 ]] || die "--snapshot-class requires a value"
+      SNAP_CLASS="$2"; shift 2 ;;
+    --dry-run)         DRY_RUN=true; shift ;;
+    *) echo "Unknown argument: $1"; exit 1 ;;
+  esac
+done
+
+if [[ ! "$SNAP_NAME" =~ ^[a-z0-9]([a-z0-9.-]*[a-z0-9])?$ ]]; then
+  die "Invalid snapshot name '${SNAP_NAME}'. Must be a valid Kubernetes resource name (lowercase alphanumeric, hyphens, dots)."
+fi
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+info()    { echo "[INFO]  $*"; }
+success() { echo "[OK]    $*"; }
+warn()    { echo "[WARN]  $*"; }
+
+require_cmd() { command -v "$1" &>/dev/null || die "'$1' is required but not found in PATH"; }
+require_cmd oc
+
+golden_snapshot_summary() {
+  echo ""
+  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+  echo "  Golden snapshot ready"
+  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+  echo "  Snapshot:       ${SNAP_NAME}"
+  echo "  Namespace:      ${PVC_NAMESPACE}"
+  echo "  StorageClass:   ${SOURCE_SC}"
+  echo "  AZ:             ${SOURCE_AZ:-unknown}"
+  echo ""
+  echo "  Launch VMs:"
+  echo "    ./6_launch_vm.sh --count 5"
+  echo ""
+  echo "  For Go tests:"
+  echo "    export KVP_WINDOWS_SNAPSHOT_NAME=${SNAP_NAME}"
+  echo "    export KVP_WINDOWS_SNAPSHOT_NS=${PVC_NAMESPACE}"
+  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+}
+
+# ---------------------------------------------------------------------------
+# Step 0: verify cluster access
+# ---------------------------------------------------------------------------
+info "Verifying cluster access..."
+oc cluster-info --request-timeout=10s &>/dev/null || die "Cannot reach the cluster. Check your kubeconfig / oc login."
+success "Cluster reachable."
+
+# ---------------------------------------------------------------------------
+# Step 1: verify the windows DataVolume is Succeeded
+# ---------------------------------------------------------------------------
+info "Checking DataVolume '${PVC_NAME}' in namespace '${PVC_NAMESPACE}'..."
+DV_PHASE=$(oc get datavolume "$PVC_NAME" -n "$PVC_NAMESPACE" -o jsonpath='{.status.phase}' 2>/dev/null || echo "NotFound")
+
+if [[ "$DV_PHASE" != "Succeeded" ]]; then
+  die "DataVolume '${PVC_NAME}' is in phase '${DV_PHASE}' (expected 'Succeeded'). Run 2_setup-storageclass.sh first and wait for the import to complete."
+fi
+success "DataVolume '${PVC_NAME}' is Succeeded."
+
+# ---------------------------------------------------------------------------
+# Step 2: verify the PVC exists
+# ---------------------------------------------------------------------------
+if ! oc get pvc "$PVC_NAME" -n "$PVC_NAMESPACE" &>/dev/null; then
+  die "PVC '${PVC_NAME}' not found in namespace '${PVC_NAMESPACE}'."
+fi
+
+# ---------------------------------------------------------------------------
+# Step 3: detect the source PVC's AZ and StorageClass
+# ---------------------------------------------------------------------------
+info "Detecting source PVC availability zone and StorageClass..."
+
+SOURCE_SC=$(oc get pvc "$PVC_NAME" -n "$PVC_NAMESPACE" -o jsonpath='{.spec.storageClassName}')
+PV_NAME=$(oc get pvc "$PVC_NAME" -n "$PVC_NAMESPACE" -o jsonpath='{.spec.volumeName}')
+SOURCE_AZ=""
+if [[ -n "$PV_NAME" ]]; then
+  SOURCE_AZ=$(oc get pv "$PV_NAME" -o jsonpath='{.metadata.labels.topology\.kubernetes\.io/zone}' 2>/dev/null || true)
+fi
+
+info "Source StorageClass: ${SOURCE_SC:-unknown}"
+info "Source AZ: ${SOURCE_AZ:-unknown}"
+
+# ---------------------------------------------------------------------------
+# Step 4: find or validate VolumeSnapshotClass
+# ---------------------------------------------------------------------------
+if ! oc get volumesnapshotclass "$SNAP_CLASS" &>/dev/null; then
+  die "VolumeSnapshotClass '${SNAP_CLASS}' not found. Create it or pass --snapshot-class."
+fi
+info "Using VolumeSnapshotClass: ${SNAP_CLASS} (deletionPolicy: $(oc get volumesnapshotclass "$SNAP_CLASS" -o jsonpath='{.deletionPolicy}'))"
+
+# ---------------------------------------------------------------------------
+# Step 5: check for existing snapshot
+# ---------------------------------------------------------------------------
+if oc get volumesnapshot "$SNAP_NAME" -n "$PVC_NAMESPACE" &>/dev/null; then
+  EXISTING_READY=$(oc get volumesnapshot "$SNAP_NAME" -n "$PVC_NAMESPACE" -o jsonpath='{.status.readyToUse}' 2>/dev/null || echo "false")
+  if [[ "$EXISTING_READY" == "true" ]]; then
+    warn "VolumeSnapshot '${SNAP_NAME}' already exists and is ready."
+    warn "Skipping creation. Delete it first if you want to recreate:"
+    warn "  oc delete volumesnapshot ${SNAP_NAME} -n ${PVC_NAMESPACE}"
+
+    if ! $DRY_RUN; then
+      info "Writing ${ENV_FILE}..."
+      cat > "$ENV_FILE" <<ENVEOF
+GOLDEN_SNAPSHOT_NAME=${SNAP_NAME}
+GOLDEN_SNAPSHOT_NS=${PVC_NAMESPACE}
+GOLDEN_SC=${SOURCE_SC}
+GOLDEN_AZ=${SOURCE_AZ}
+ENVEOF
+      success "Env file written: ${ENV_FILE}"
+    else
+      info "Dry-run: skipping ${ENV_FILE}"
+    fi
+    golden_snapshot_summary
+    exit 0
+  else
+    warn "VolumeSnapshot '${SNAP_NAME}' exists but is not ready. Deleting and recreating..."
+    if $DRY_RUN; then
+      warn "Dry-run: not deleting existing VolumeSnapshot; manifest below is what would be applied."
+    else
+      oc delete volumesnapshot "$SNAP_NAME" -n "$PVC_NAMESPACE"
+      sleep 2
+    fi
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# Step 6: create the VolumeSnapshot
+# ---------------------------------------------------------------------------
+info "Creating VolumeSnapshot '${SNAP_NAME}' from PVC '${PVC_NAME}'..."
+
+SNAP_MANIFEST=$(cat <<EOF
+apiVersion: snapshot.storage.k8s.io/v1
+kind: VolumeSnapshot
+metadata:
+  name: ${SNAP_NAME}
+  namespace: ${PVC_NAMESPACE}
+  labels:
+    app.kubernetes.io/managed-by: oadp-kubevirt-windows-test
+    app.kubernetes.io/created-by: 5_create-golden-snapshot.sh
+spec:
+  volumeSnapshotClassName: ${SNAP_CLASS}
+  source:
+    persistentVolumeClaimName: ${PVC_NAME}
+EOF
+)
+
+if $DRY_RUN; then
+  echo ""
+  echo "=== DRY RUN — VolumeSnapshot manifest that would be applied ==="
+  echo "$SNAP_MANIFEST"
+  echo "================================================================"
+  exit 0
+fi
+
+echo "$SNAP_MANIFEST" | oc apply -f -
+
+# ---------------------------------------------------------------------------
+# Step 7: wait for snapshot to become ready
+# ---------------------------------------------------------------------------
+info "Waiting for VolumeSnapshot to become readyToUse..."
+
+READY=false
+TIMEOUT=1800
+ELAPSED=0
+while [[ $ELAPSED -lt $TIMEOUT ]]; do
+  READY=$(oc get volumesnapshot "$SNAP_NAME" -n "$PVC_NAMESPACE" -o jsonpath='{.status.readyToUse}' 2>/dev/null || echo "false")
+  if [[ "$READY" == "true" ]]; then
+    break
+  fi
+  printf "\r  Waiting... (%ds / %ds)" "$ELAPSED" "$TIMEOUT"
+  sleep 5
+  ELAPSED=$((ELAPSED + 5))
+done
+
+if [[ "$READY" != "true" ]]; then
+  echo ""
+  die "VolumeSnapshot '${SNAP_NAME}' did not become ready within ${TIMEOUT}s."
+fi
+
+echo ""
+success "VolumeSnapshot '${SNAP_NAME}' is ready."
+
+SNAP_SIZE=$(oc get volumesnapshot "$SNAP_NAME" -n "$PVC_NAMESPACE" -o jsonpath='{.status.restoreSize}' 2>/dev/null || echo "unknown")
+info "Snapshot restore size: ${SNAP_SIZE}"
+
+# ---------------------------------------------------------------------------
+# Step 8: write env file
+# ---------------------------------------------------------------------------
+info "Writing ${ENV_FILE}..."
+cat > "$ENV_FILE" <<ENVEOF
+GOLDEN_SNAPSHOT_NAME=${SNAP_NAME}
+GOLDEN_SNAPSHOT_NS=${PVC_NAMESPACE}
+GOLDEN_SC=${SOURCE_SC}
+GOLDEN_AZ=${SOURCE_AZ}
+ENVEOF
+success "Env file written: ${ENV_FILE}"
+
+golden_snapshot_summary

--- a/manifests/windows-vm/get-cluster-info.sh
+++ b/manifests/windows-vm/get-cluster-info.sh
@@ -1,18 +1,23 @@
 #!/bin/bash
 #
-# Get cluster infraID and region for IRSA setup
+# Get cluster info and configure S3 access for Windows image import
 #
-# This helper script extracts the infraID and region from a running cluster
-# so you can use them with setup-irsa.sh
+# Detects whether the cluster supports IRSA (STS mode with OIDC) and falls
+# back to static credentials from ~/.aws/credentials when it does not.
 #
 # Usage:
 #   ./get-cluster-info.sh
 #
 # Prerequisites:
 # - oc CLI must be installed and logged into the cluster
+# - For static credentials fallback: ~/.aws/credentials must exist
 #
 
 set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SERVICE_ACCOUNT_NAME="windows-image-importer"
+SERVICE_ACCOUNT_NAMESPACE="openshift-virtualization-os-images"
 
 echo "Getting cluster information..."
 echo ""
@@ -44,9 +49,90 @@ echo "━━━━━━━━━━━━━━━━━━━━━━━━�
 echo "Cluster Name: $CLUSTER_NAME"
 echo "Infrastructure ID: $INFRA_ID"
 echo "Region: $REGION"
-echo "OIDC Issuer: $OIDC_ISSUER"
+echo "OIDC Issuer: ${OIDC_ISSUER:-<not configured>}"
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 echo ""
-echo "To setup IRSA, run:"
-echo "  ./setup-irsa.sh $INFRA_ID $REGION"
+
+if [ -n "$OIDC_ISSUER" ]; then
+  echo "✓ Cluster has STS mode enabled (OIDC issuer found)"
+  echo ""
+  echo "To setup IRSA, run:"
+  echo "  ./setup-irsa.sh $INFRA_ID $REGION"
+  echo ""
+  exit 0
+fi
+
+# --- Static credentials fallback ---
+
+echo "⚠ Cluster does NOT have STS mode enabled (no OIDC issuer)."
+echo "  IRSA is not available. Falling back to static AWS credentials."
 echo ""
+
+AWS_CREDS_FILE="${AWS_SHARED_CREDENTIALS_FILE:-$HOME/.aws/credentials}"
+
+if [ ! -f "$AWS_CREDS_FILE" ]; then
+  echo "ERROR: AWS credentials file not found at $AWS_CREDS_FILE"
+  echo ""
+  echo "Create it with 'aws configure' or manually:"
+  echo "  mkdir -p ~/.aws"
+  echo "  cat > ~/.aws/credentials <<EOF"
+  echo "  [default]"
+  echo "  aws_access_key_id = YOUR_KEY"
+  echo "  aws_secret_access_key = YOUR_SECRET"
+  echo "  EOF"
+  exit 1
+fi
+
+AWS_PROFILE="${AWS_PROFILE:-default}"
+
+# Parse credentials from the AWS credentials file
+ACCESS_KEY=$(aws configure get aws_access_key_id --profile "$AWS_PROFILE" 2>/dev/null || true)
+SECRET_KEY=$(aws configure get aws_secret_access_key --profile "$AWS_PROFILE" 2>/dev/null || true)
+
+if [ -z "$ACCESS_KEY" ] || [ -z "$SECRET_KEY" ]; then
+  echo "ERROR: Could not read credentials from profile '$AWS_PROFILE' in $AWS_CREDS_FILE"
+  exit 1
+fi
+
+echo "✓ Found AWS credentials (profile: $AWS_PROFILE)"
+echo "  Access Key: ${ACCESS_KEY:0:4}...${ACCESS_KEY: -4}"
+echo ""
+
+# Ensure namespace exists
+oc create namespace "$SERVICE_ACCOUNT_NAMESPACE" --dry-run=client -o yaml | oc apply -f - 2>/dev/null
+echo "✓ Namespace: $SERVICE_ACCOUNT_NAMESPACE"
+
+# Create the secret directly in the cluster — never written to disk
+oc create secret generic s3-credentials \
+  --namespace="$SERVICE_ACCOUNT_NAMESPACE" \
+  --from-literal=accessKeyId="$ACCESS_KEY" \
+  --from-literal=secretKey="$SECRET_KEY" \
+  --dry-run=client -o yaml | oc apply -f -
+echo "✓ Secret created: s3-credentials (in-cluster only, not written to disk)"
+
+# CDI DataVolumes are immutable — delete first if one already exists
+if oc get datavolume windows -n "$SERVICE_ACCOUNT_NAMESPACE" &>/dev/null; then
+  echo "  Existing DataVolume found, deleting (CDI does not allow spec updates)..."
+  oc delete datavolume windows -n "$SERVICE_ACCOUNT_NAMESPACE" --wait=true
+fi
+oc apply -f "${SCRIPT_DIR}/2_windows-datavolume.yaml"
+echo "✓ Applied: 2_windows-datavolume.yaml"
+
+# Apply remaining manifests
+oc apply -f "${SCRIPT_DIR}/3_datasource-windows.yaml"
+echo "✓ Applied: 3_datasource-windows.yaml"
+
+oc apply -f "${SCRIPT_DIR}/4_windows10-template.yaml"
+echo "✓ Applied: 4_windows10-template.yaml"
+
+echo ""
+echo "═══════════════════════════════════════════════════════════════"
+echo "  Static Credentials Setup Complete"
+echo "═══════════════════════════════════════════════════════════════"
+echo ""
+echo "The s3-credentials Secret was created directly in the cluster"
+echo "from ~/.aws/credentials. No secrets were written to disk."
+echo ""
+echo "Monitor the import:"
+echo "  oc get datavolume windows -n ${SERVICE_ACCOUNT_NAMESPACE} -w"
+echo "═══════════════════════════════════════════════════════════════"

--- a/manifests/windows-vm/get-cluster-info.sh
+++ b/manifests/windows-vm/get-cluster-info.sh
@@ -44,11 +44,23 @@ CLUSTER_NAME=$(oc get infrastructure cluster -o jsonpath='{.status.apiServerURL}
 # Get OIDC provider info
 OIDC_ISSUER=$(oc get authentication.config.openshift.io cluster -o jsonpath='{.spec.serviceAccountIssuer}')
 
+# Detect availability zone from default storage class
+DEFAULT_SC=$(oc get storageclass -o json | jq -r '.items[] | select(.metadata.annotations."storageclass.kubernetes.io/is-default-class" == "true") | .metadata.name' | head -1)
+DETECTED_AZ=""
+if [[ -n "$DEFAULT_SC" ]]; then
+  # Try to extract AZ from storage class name (common pattern: *-us-east-1b)
+  if [[ "$DEFAULT_SC" =~ -([a-z]+-[a-z]+-[0-9]+[a-z])$ ]]; then
+    DETECTED_AZ="${BASH_REMATCH[1]}"
+  fi
+fi
+
 echo "Cluster Information:"
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 echo "Cluster Name: $CLUSTER_NAME"
 echo "Infrastructure ID: $INFRA_ID"
 echo "Region: $REGION"
+echo "Availability Zone: ${DETECTED_AZ:-<will be detected from PVC>}"
+echo "Default StorageClass: ${DEFAULT_SC:-<none>}"
 echo "OIDC Issuer: ${OIDC_ISSUER:-<not configured>}"
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 echo ""

--- a/manifests/windows-vm/setup-irsa.sh
+++ b/manifests/windows-vm/setup-irsa.sh
@@ -169,7 +169,7 @@ spec:
   source:
     s3:
       # S3 URL format: s3://bucket-name/path/to/object
-      url: "s3://ocpctl-binaries/windows-images/windows-10-oadp.qcow2"
+      url: "https://ocpctl-binaries.s3.us-east-1.amazonaws.com/windows-images/windows-10-oadp.qcow2"
       # Use IRSA instead of secretRef - credentials come from ServiceAccount
       # No secretRef needed!
   storage:

--- a/scripts/manage-windows-volumesnapshot.sh
+++ b/scripts/manage-windows-volumesnapshot.sh
@@ -1,22 +1,25 @@
 #!/bin/bash
 #
-# 5_create-golden-snapshot.sh - Create a VolumeSnapshot of the Windows golden image
+# manage-windows-volumesnapshot.sh - Manage a VolumeSnapshot of the Windows golden image
 #
 # Takes a VolumeSnapshot of the 'windows' PVC in openshift-virtualization-os-images.
 # Subsequent VM launches can restore from this snapshot (~2-5 min on EBS) instead of
 # cloning from the DataSource (~30 min per VM).
 #
 # Prerequisites:
-#   - 'windows' DataVolume must be in Succeeded phase (run 2_setup-storageclass.sh first)
+#   - 'windows' DataVolume must be in Succeeded phase
 #   - A VolumeSnapshotClass must exist for the cluster's CSI driver
 #
 # Usage:
-#   ./5_create-golden-snapshot.sh [--name <name>] [--snapshot-class <class>] [--dry-run]
+#   ./manage-windows-volumesnapshot.sh [--name <name>] [--snapshot-class <class>] [--dry-run]
+#   ./manage-windows-volumesnapshot.sh --status [--wait] [--name <name>]
 #
 # Examples:
-#   ./5_create-golden-snapshot.sh
-#   ./5_create-golden-snapshot.sh --name my-snap
-#   ./5_create-golden-snapshot.sh --dry-run
+#   ./manage-windows-volumesnapshot.sh
+#   ./manage-windows-volumesnapshot.sh --name my-snap
+#   ./manage-windows-volumesnapshot.sh --dry-run
+#   ./manage-windows-volumesnapshot.sh --status
+#   ./manage-windows-volumesnapshot.sh --status --wait
 
 set -euo pipefail
 
@@ -28,8 +31,8 @@ PVC_NAMESPACE="openshift-virtualization-os-images"
 SNAP_NAME="windows-golden-snap"
 SNAP_CLASS="csi-aws-vsc"
 DRY_RUN=false
-
-die() { echo "[ERROR] $*" >&2; exit 1; }
+STATUS_ONLY=false
+STATUS_WAIT=false
 
 # ---------------------------------------------------------------------------
 # Argument parsing
@@ -37,29 +40,106 @@ die() { echo "[ERROR] $*" >&2; exit 1; }
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --name)
-      [[ $# -ge 2 ]] || die "--name requires a value"
+      [[ $# -ge 2 ]] || { echo "[ERROR] --name requires a value" >&2; exit 1; }
       SNAP_NAME="$2"; shift 2 ;;
     --snapshot-class)
-      [[ $# -ge 2 ]] || die "--snapshot-class requires a value"
+      [[ $# -ge 2 ]] || { echo "[ERROR] --snapshot-class requires a value" >&2; exit 1; }
       SNAP_CLASS="$2"; shift 2 ;;
-    --dry-run)         DRY_RUN=true; shift ;;
+    --dry-run)  DRY_RUN=true;    shift ;;
+    --status)   STATUS_ONLY=true; shift ;;
+    --wait)     STATUS_WAIT=true; shift ;;
     *) echo "Unknown argument: $1"; exit 1 ;;
   esac
 done
 
 if [[ ! "$SNAP_NAME" =~ ^[a-z0-9]([a-z0-9.-]*[a-z0-9])?$ ]]; then
-  die "Invalid snapshot name '${SNAP_NAME}'. Must be a valid Kubernetes resource name (lowercase alphanumeric, hyphens, dots)."
+  echo "[ERROR] Invalid snapshot name '${SNAP_NAME}'." >&2; exit 1
 fi
 
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+die()     { echo "[ERROR] $*" >&2; exit 1; }
 info()    { echo "[INFO]  $*"; }
 success() { echo "[OK]    $*"; }
 warn()    { echo "[WARN]  $*"; }
 
 require_cmd() { command -v "$1" &>/dev/null || die "'$1' is required but not found in PATH"; }
 require_cmd oc
+
+snap_field() {
+  oc get volumesnapshot "$SNAP_NAME" -n "$PVC_NAMESPACE" -o jsonpath="$1" 2>/dev/null || echo "${2:-unknown}"
+}
+
+detect_az() {
+  local pv="$1" az=""
+  az=$(oc get pv "$pv" -o jsonpath='{.metadata.labels.topology\.kubernetes\.io/zone}' 2>/dev/null || true)
+  if [[ -z "$az" ]]; then
+    az=$(oc get pv "$pv" -o jsonpath='{.spec.nodeAffinity.required.nodeSelectorTerms[0].matchExpressions[?(@.key=="topology.kubernetes.io/zone")].values[0]}' 2>/dev/null || true)
+  fi
+  echo "$az"
+}
+
+region_from_az() {
+  [[ -n "$1" ]] && echo "${1%[a-f]}" || true
+}
+
+# Resolve VolumeSnapshot -> VolumeSnapshotContent -> EBS snapshot handle
+resolve_ebs_handle() {
+  local content handle=""
+  content=$(snap_field '{.status.boundVolumeSnapshotContentName}' "")
+  if [[ -n "$content" ]]; then
+    handle=$(oc get volumesnapshotcontent "$content" -o jsonpath='{.status.snapshotHandle}' 2>/dev/null || true)
+  fi
+  echo "$handle"
+}
+
+# Query EBS snapshot state and progress; sets EBS_STATE and EBS_PROGRESS
+query_ebs() {
+  EBS_STATE="" EBS_PROGRESS=""
+  [[ -n "$AWS_REGION" ]] && command -v aws &>/dev/null || return 0
+  local handle
+  handle=$(resolve_ebs_handle)
+  [[ -n "$handle" ]] || return 0
+  EBS_HANDLE="$handle"
+  EBS_PROGRESS=$(aws ec2 describe-snapshots --snapshot-ids "$handle" \
+    --query 'Snapshots[0].Progress' --output text --region "$AWS_REGION" 2>/dev/null || true)
+  EBS_STATE=$(aws ec2 describe-snapshots --snapshot-ids "$handle" \
+    --query 'Snapshots[0].State' --output text --region "$AWS_REGION" 2>/dev/null || true)
+}
+
+print_status() {
+  local ready restore_size creation_time snap_class
+  ready=$(snap_field '{.status.readyToUse}' "unknown")
+  restore_size=$(snap_field '{.status.restoreSize}' "unknown")
+  creation_time=$(snap_field '{.status.creationTime}' "unknown")
+  snap_class=$(snap_field '{.spec.volumeSnapshotClassName}' "unknown")
+  LAST_READY="$ready"
+
+  echo ""
+  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+  echo "  VolumeSnapshot Status"
+  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+  echo "  Snapshot:       ${SNAP_NAME}"
+  echo "  Namespace:      ${PVC_NAMESPACE}"
+  echo "  ReadyToUse:     ${ready}"
+  echo "  RestoreSize:    ${restore_size}"
+  echo "  CreationTime:   ${creation_time}"
+  echo "  SnapshotClass:  ${snap_class}"
+  echo "  StorageClass:   ${SOURCE_SC:-unknown}"
+  echo "  AZ:             ${SOURCE_AZ:-unknown}"
+
+  EBS_HANDLE=""
+  query_ebs
+  if [[ -n "$EBS_STATE" ]]; then
+    echo ""
+    echo "  EBS Snapshot:   ${EBS_HANDLE}"
+    echo "  EBS State:      ${EBS_STATE}"
+    echo "  EBS Progress:   ${EBS_PROGRESS:-unknown}"
+  fi
+
+  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+}
 
 golden_snapshot_summary() {
   echo ""
@@ -80,75 +160,123 @@ golden_snapshot_summary() {
   echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 }
 
+write_env_file() {
+  info "Writing ${ENV_FILE}..."
+  cat > "$ENV_FILE" <<ENVEOF
+GOLDEN_SNAPSHOT_NAME=${SNAP_NAME}
+GOLDEN_SNAPSHOT_NS=${PVC_NAMESPACE}
+GOLDEN_SC=${SOURCE_SC}
+ENVEOF
+  success "Env file written: ${ENV_FILE}"
+}
+
+# Wait for VolumeSnapshot readyToUse with progress display
+wait_for_snapshot() {
+  local timeout=$1 interval=$2
+  info "Waiting for VolumeSnapshot to become readyToUse..."
+  local elapsed=0
+  while [[ $elapsed -lt $timeout ]]; do
+    local ready
+    ready=$(snap_field '{.status.readyToUse}' "false")
+    [[ "$ready" == "true" ]] && { echo ""; return 0; }
+
+    EBS_HANDLE=""
+    query_ebs
+    if [[ -n "$EBS_PROGRESS" ]]; then
+      printf "\r  Waiting... (%ds / %ds) | EBS snapshot progress: %s" "$elapsed" "$timeout" "$EBS_PROGRESS"
+    else
+      printf "\r  Waiting... (%ds / %ds)" "$elapsed" "$timeout"
+    fi
+
+    sleep "$interval"
+    elapsed=$((elapsed + interval))
+  done
+  echo ""
+  return 1
+}
+
 # ---------------------------------------------------------------------------
-# Step 0: verify cluster access
+# Preflight: verify cluster access and source PVC
 # ---------------------------------------------------------------------------
 info "Verifying cluster access..."
 oc cluster-info --request-timeout=10s &>/dev/null || die "Cannot reach the cluster. Check your kubeconfig / oc login."
 success "Cluster reachable."
 
-# ---------------------------------------------------------------------------
-# Step 1: verify the windows DataVolume is Succeeded
-# ---------------------------------------------------------------------------
 info "Checking DataVolume '${PVC_NAME}' in namespace '${PVC_NAMESPACE}'..."
 DV_PHASE=$(oc get datavolume "$PVC_NAME" -n "$PVC_NAMESPACE" -o jsonpath='{.status.phase}' 2>/dev/null || echo "NotFound")
-
-if [[ "$DV_PHASE" != "Succeeded" ]]; then
-  die "DataVolume '${PVC_NAME}' is in phase '${DV_PHASE}' (expected 'Succeeded'). Run 2_setup-storageclass.sh first and wait for the import to complete."
-fi
+[[ "$DV_PHASE" == "Succeeded" ]] || die "DataVolume '${PVC_NAME}' is in phase '${DV_PHASE}' (expected 'Succeeded')."
 success "DataVolume '${PVC_NAME}' is Succeeded."
 
-# ---------------------------------------------------------------------------
-# Step 2: verify the PVC exists
-# ---------------------------------------------------------------------------
-if ! oc get pvc "$PVC_NAME" -n "$PVC_NAMESPACE" &>/dev/null; then
-  die "PVC '${PVC_NAME}' not found in namespace '${PVC_NAMESPACE}'."
-fi
+oc get pvc "$PVC_NAME" -n "$PVC_NAMESPACE" &>/dev/null || die "PVC '${PVC_NAME}' not found in namespace '${PVC_NAMESPACE}'."
 
-# ---------------------------------------------------------------------------
-# Step 3: detect the source PVC's AZ and StorageClass
-# ---------------------------------------------------------------------------
 info "Detecting source PVC availability zone and StorageClass..."
-
 SOURCE_SC=$(oc get pvc "$PVC_NAME" -n "$PVC_NAMESPACE" -o jsonpath='{.spec.storageClassName}')
 PV_NAME=$(oc get pvc "$PVC_NAME" -n "$PVC_NAMESPACE" -o jsonpath='{.spec.volumeName}')
 SOURCE_AZ=""
-if [[ -n "$PV_NAME" ]]; then
-  SOURCE_AZ=$(oc get pv "$PV_NAME" -o jsonpath='{.metadata.labels.topology\.kubernetes\.io/zone}' 2>/dev/null || true)
-fi
+[[ -n "$PV_NAME" ]] && SOURCE_AZ=$(detect_az "$PV_NAME")
+AWS_REGION=$(region_from_az "$SOURCE_AZ")
 
 info "Source StorageClass: ${SOURCE_SC:-unknown}"
 info "Source AZ: ${SOURCE_AZ:-unknown}"
 
 # ---------------------------------------------------------------------------
-# Step 4: find or validate VolumeSnapshotClass
+# --status mode
 # ---------------------------------------------------------------------------
-if ! oc get volumesnapshotclass "$SNAP_CLASS" &>/dev/null; then
-  die "VolumeSnapshotClass '${SNAP_CLASS}' not found. Create it or pass --snapshot-class."
+if $STATUS_ONLY; then
+  if ! oc get volumesnapshot "$SNAP_NAME" -n "$PVC_NAMESPACE" &>/dev/null; then
+    echo ""
+    echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+    echo "  Snapshot:       ${SNAP_NAME} (not found)"
+    echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+    exit 0
+  fi
+
+  LAST_READY="unknown"
+
+  if ! $STATUS_WAIT; then
+    print_status
+    exit 0
+  fi
+
+  info "Polling snapshot status (Ctrl-C to stop)..."
+  TIMEOUT=3600
+  ELAPSED=0
+  while [[ $ELAPSED -lt $TIMEOUT ]]; do
+    clear 2>/dev/null || printf "\033c"
+    print_status
+
+    if [[ "$LAST_READY" == "true" ]]; then
+      echo ""
+      success "VolumeSnapshot '${SNAP_NAME}' is ready."
+      break
+    fi
+
+    echo ""
+    printf "  Polling... (%ds elapsed, refreshing in 10s)\n" "$ELAPSED"
+    sleep 10
+    ELAPSED=$((ELAPSED + 10))
+  done
+
+  [[ "$LAST_READY" == "true" ]] || die "Timed out after ${TIMEOUT}s waiting for snapshot to become ready."
+  exit 0
 fi
+
+# ---------------------------------------------------------------------------
+# Create flow: validate snapshot class
+# ---------------------------------------------------------------------------
+oc get volumesnapshotclass "$SNAP_CLASS" &>/dev/null || die "VolumeSnapshotClass '${SNAP_CLASS}' not found. Create it or pass --snapshot-class."
 info "Using VolumeSnapshotClass: ${SNAP_CLASS} (deletionPolicy: $(oc get volumesnapshotclass "$SNAP_CLASS" -o jsonpath='{.deletionPolicy}'))"
 
 # ---------------------------------------------------------------------------
-# Step 5: check for existing snapshot
+# Create flow: check for existing snapshot
 # ---------------------------------------------------------------------------
 if oc get volumesnapshot "$SNAP_NAME" -n "$PVC_NAMESPACE" &>/dev/null; then
-  EXISTING_READY=$(oc get volumesnapshot "$SNAP_NAME" -n "$PVC_NAMESPACE" -o jsonpath='{.status.readyToUse}' 2>/dev/null || echo "false")
+  EXISTING_READY=$(snap_field '{.status.readyToUse}' "false")
   if [[ "$EXISTING_READY" == "true" ]]; then
     warn "VolumeSnapshot '${SNAP_NAME}' already exists and is ready."
     warn "Skipping creation. Delete it first if you want to recreate:"
     warn "  oc delete volumesnapshot ${SNAP_NAME} -n ${PVC_NAMESPACE}"
-
-    if ! $DRY_RUN; then
-      info "Writing ${ENV_FILE}..."
-      cat > "$ENV_FILE" <<ENVEOF
-GOLDEN_SNAPSHOT_NAME=${SNAP_NAME}
-GOLDEN_SNAPSHOT_NS=${PVC_NAMESPACE}
-GOLDEN_SC=${SOURCE_SC}
-ENVEOF
-      success "Env file written: ${ENV_FILE}"
-    else
-      info "Dry-run: skipping ${ENV_FILE}"
-    fi
+    $DRY_RUN || write_env_file
     golden_snapshot_summary
     exit 0
   else
@@ -163,7 +291,7 @@ ENVEOF
 fi
 
 # ---------------------------------------------------------------------------
-# Step 6: create the VolumeSnapshot
+# Create flow: apply the VolumeSnapshot
 # ---------------------------------------------------------------------------
 info "Creating VolumeSnapshot '${SNAP_NAME}' from PVC '${PVC_NAME}'..."
 
@@ -175,7 +303,7 @@ metadata:
   namespace: ${PVC_NAMESPACE}
   labels:
     app.kubernetes.io/managed-by: oadp-kubevirt-windows-test
-    app.kubernetes.io/created-by: 5_create-golden-snapshot.sh
+    app.kubernetes.io/created-by: manage-windows-volumesnapshot.sh
 spec:
   volumeSnapshotClassName: ${SNAP_CLASS}
   source:
@@ -185,74 +313,22 @@ EOF
 
 if $DRY_RUN; then
   echo ""
-  echo "=== DRY RUN — VolumeSnapshot manifest that would be applied ==="
+  echo "=== DRY RUN ==="
   echo "$SNAP_MANIFEST"
-  echo "================================================================"
+  echo "================"
   exit 0
 fi
 
 echo "$SNAP_MANIFEST" | oc apply -f -
 
 # ---------------------------------------------------------------------------
-# Step 7: wait for snapshot to become ready
+# Create flow: wait for snapshot
 # ---------------------------------------------------------------------------
-info "Waiting for VolumeSnapshot to become readyToUse..."
-
-AWS_REGION=""
-if [[ -n "${SOURCE_AZ}" ]]; then
-  AWS_REGION="${SOURCE_AZ%[a-f]}"
-fi
-
-READY=false
-TIMEOUT=1800
-ELAPSED=0
-while [[ $ELAPSED -lt $TIMEOUT ]]; do
-  READY=$(oc get volumesnapshot "$SNAP_NAME" -n "$PVC_NAMESPACE" -o jsonpath='{.status.readyToUse}' 2>/dev/null || echo "false")
-  if [[ "$READY" == "true" ]]; then
-    break
-  fi
-
-  AWS_PROGRESS=""
-  if [[ -n "$AWS_REGION" ]] && command -v aws &>/dev/null; then
-    SNAP_CONTENT=$(oc get volumesnapshot "$SNAP_NAME" -n "$PVC_NAMESPACE" -o jsonpath='{.status.boundVolumeSnapshotContentName}' 2>/dev/null || true)
-    if [[ -n "$SNAP_CONTENT" ]]; then
-      SNAP_HANDLE=$(oc get volumesnapshotcontent "$SNAP_CONTENT" -o jsonpath='{.status.snapshotHandle}' 2>/dev/null || true)
-      if [[ -n "$SNAP_HANDLE" ]]; then
-        AWS_PROGRESS=$(aws ec2 describe-snapshots --snapshot-ids "$SNAP_HANDLE" \
-          --query 'Snapshots[0].Progress' --output text --region "$AWS_REGION" 2>/dev/null || true)
-      fi
-    fi
-  fi
-
-  if [[ -n "$AWS_PROGRESS" ]]; then
-    printf "\r  Waiting... (%ds / %ds) — EBS snapshot progress: %s" "$ELAPSED" "$TIMEOUT" "$AWS_PROGRESS"
-  else
-    printf "\r  Waiting... (%ds / %ds)" "$ELAPSED" "$TIMEOUT"
-  fi
-  sleep 5
-  ELAPSED=$((ELAPSED + 5))
-done
-
-if [[ "$READY" != "true" ]]; then
-  echo ""
-  die "VolumeSnapshot '${SNAP_NAME}' did not become ready within ${TIMEOUT}s."
-fi
-
-echo ""
+wait_for_snapshot 1800 5 || die "VolumeSnapshot '${SNAP_NAME}' did not become ready within 1800s."
 success "VolumeSnapshot '${SNAP_NAME}' is ready."
 
-SNAP_SIZE=$(oc get volumesnapshot "$SNAP_NAME" -n "$PVC_NAMESPACE" -o jsonpath='{.status.restoreSize}' 2>/dev/null || echo "unknown")
+SNAP_SIZE=$(snap_field '{.status.restoreSize}' "unknown")
 info "Snapshot restore size: ${SNAP_SIZE}"
 
-# ---------------------------------------------------------------------------
-# Step 8: write env file
-# ---------------------------------------------------------------------------
-info "Writing ${ENV_FILE}..."
-cat > "$ENV_FILE" <<ENVEOF
-GOLDEN_SNAPSHOT_NAME=${SNAP_NAME}
-GOLDEN_SNAPSHOT_NS=${PVC_NAMESPACE}
-GOLDEN_SC=${SOURCE_SC}
-ENVEOF
-success "Env file written: ${ENV_FILE}"
-
+write_env_file
 golden_snapshot_summary

--- a/scripts/manage-windows-volumesnapshot.sh
+++ b/scripts/manage-windows-volumesnapshot.sh
@@ -1,0 +1,258 @@
+#!/bin/bash
+#
+# 5_create-golden-snapshot.sh - Create a VolumeSnapshot of the Windows golden image
+#
+# Takes a VolumeSnapshot of the 'windows' PVC in openshift-virtualization-os-images.
+# Subsequent VM launches can restore from this snapshot (~2-5 min on EBS) instead of
+# cloning from the DataSource (~30 min per VM).
+#
+# Prerequisites:
+#   - 'windows' DataVolume must be in Succeeded phase (run 2_setup-storageclass.sh first)
+#   - A VolumeSnapshotClass must exist for the cluster's CSI driver
+#
+# Usage:
+#   ./5_create-golden-snapshot.sh [--name <name>] [--snapshot-class <class>] [--dry-run]
+#
+# Examples:
+#   ./5_create-golden-snapshot.sh
+#   ./5_create-golden-snapshot.sh --name my-snap
+#   ./5_create-golden-snapshot.sh --dry-run
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ENV_FILE="${SCRIPT_DIR}/.golden-snapshot.env"
+
+PVC_NAME="windows"
+PVC_NAMESPACE="openshift-virtualization-os-images"
+SNAP_NAME="windows-golden-snap"
+SNAP_CLASS="csi-aws-vsc"
+DRY_RUN=false
+
+die() { echo "[ERROR] $*" >&2; exit 1; }
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --name)
+      [[ $# -ge 2 ]] || die "--name requires a value"
+      SNAP_NAME="$2"; shift 2 ;;
+    --snapshot-class)
+      [[ $# -ge 2 ]] || die "--snapshot-class requires a value"
+      SNAP_CLASS="$2"; shift 2 ;;
+    --dry-run)         DRY_RUN=true; shift ;;
+    *) echo "Unknown argument: $1"; exit 1 ;;
+  esac
+done
+
+if [[ ! "$SNAP_NAME" =~ ^[a-z0-9]([a-z0-9.-]*[a-z0-9])?$ ]]; then
+  die "Invalid snapshot name '${SNAP_NAME}'. Must be a valid Kubernetes resource name (lowercase alphanumeric, hyphens, dots)."
+fi
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+info()    { echo "[INFO]  $*"; }
+success() { echo "[OK]    $*"; }
+warn()    { echo "[WARN]  $*"; }
+
+require_cmd() { command -v "$1" &>/dev/null || die "'$1' is required but not found in PATH"; }
+require_cmd oc
+
+golden_snapshot_summary() {
+  echo ""
+  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+  echo "  Golden snapshot ready"
+  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+  echo "  Snapshot:       ${SNAP_NAME}"
+  echo "  Namespace:      ${PVC_NAMESPACE}"
+  echo "  StorageClass:   ${SOURCE_SC}"
+  echo "  AZ:             ${SOURCE_AZ:-unknown}"
+  echo ""
+  echo "  Launch VMs:"
+  echo "    ./6_launch_vm.sh --count 5"
+  echo ""
+  echo "  For Go tests:"
+  echo "    export KVP_WINDOWS_SNAPSHOT_NAME=${SNAP_NAME}"
+  echo "    export KVP_WINDOWS_SNAPSHOT_NS=${PVC_NAMESPACE}"
+  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+}
+
+# ---------------------------------------------------------------------------
+# Step 0: verify cluster access
+# ---------------------------------------------------------------------------
+info "Verifying cluster access..."
+oc cluster-info --request-timeout=10s &>/dev/null || die "Cannot reach the cluster. Check your kubeconfig / oc login."
+success "Cluster reachable."
+
+# ---------------------------------------------------------------------------
+# Step 1: verify the windows DataVolume is Succeeded
+# ---------------------------------------------------------------------------
+info "Checking DataVolume '${PVC_NAME}' in namespace '${PVC_NAMESPACE}'..."
+DV_PHASE=$(oc get datavolume "$PVC_NAME" -n "$PVC_NAMESPACE" -o jsonpath='{.status.phase}' 2>/dev/null || echo "NotFound")
+
+if [[ "$DV_PHASE" != "Succeeded" ]]; then
+  die "DataVolume '${PVC_NAME}' is in phase '${DV_PHASE}' (expected 'Succeeded'). Run 2_setup-storageclass.sh first and wait for the import to complete."
+fi
+success "DataVolume '${PVC_NAME}' is Succeeded."
+
+# ---------------------------------------------------------------------------
+# Step 2: verify the PVC exists
+# ---------------------------------------------------------------------------
+if ! oc get pvc "$PVC_NAME" -n "$PVC_NAMESPACE" &>/dev/null; then
+  die "PVC '${PVC_NAME}' not found in namespace '${PVC_NAMESPACE}'."
+fi
+
+# ---------------------------------------------------------------------------
+# Step 3: detect the source PVC's AZ and StorageClass
+# ---------------------------------------------------------------------------
+info "Detecting source PVC availability zone and StorageClass..."
+
+SOURCE_SC=$(oc get pvc "$PVC_NAME" -n "$PVC_NAMESPACE" -o jsonpath='{.spec.storageClassName}')
+PV_NAME=$(oc get pvc "$PVC_NAME" -n "$PVC_NAMESPACE" -o jsonpath='{.spec.volumeName}')
+SOURCE_AZ=""
+if [[ -n "$PV_NAME" ]]; then
+  SOURCE_AZ=$(oc get pv "$PV_NAME" -o jsonpath='{.metadata.labels.topology\.kubernetes\.io/zone}' 2>/dev/null || true)
+fi
+
+info "Source StorageClass: ${SOURCE_SC:-unknown}"
+info "Source AZ: ${SOURCE_AZ:-unknown}"
+
+# ---------------------------------------------------------------------------
+# Step 4: find or validate VolumeSnapshotClass
+# ---------------------------------------------------------------------------
+if ! oc get volumesnapshotclass "$SNAP_CLASS" &>/dev/null; then
+  die "VolumeSnapshotClass '${SNAP_CLASS}' not found. Create it or pass --snapshot-class."
+fi
+info "Using VolumeSnapshotClass: ${SNAP_CLASS} (deletionPolicy: $(oc get volumesnapshotclass "$SNAP_CLASS" -o jsonpath='{.deletionPolicy}'))"
+
+# ---------------------------------------------------------------------------
+# Step 5: check for existing snapshot
+# ---------------------------------------------------------------------------
+if oc get volumesnapshot "$SNAP_NAME" -n "$PVC_NAMESPACE" &>/dev/null; then
+  EXISTING_READY=$(oc get volumesnapshot "$SNAP_NAME" -n "$PVC_NAMESPACE" -o jsonpath='{.status.readyToUse}' 2>/dev/null || echo "false")
+  if [[ "$EXISTING_READY" == "true" ]]; then
+    warn "VolumeSnapshot '${SNAP_NAME}' already exists and is ready."
+    warn "Skipping creation. Delete it first if you want to recreate:"
+    warn "  oc delete volumesnapshot ${SNAP_NAME} -n ${PVC_NAMESPACE}"
+
+    if ! $DRY_RUN; then
+      info "Writing ${ENV_FILE}..."
+      cat > "$ENV_FILE" <<ENVEOF
+GOLDEN_SNAPSHOT_NAME=${SNAP_NAME}
+GOLDEN_SNAPSHOT_NS=${PVC_NAMESPACE}
+GOLDEN_SC=${SOURCE_SC}
+ENVEOF
+      success "Env file written: ${ENV_FILE}"
+    else
+      info "Dry-run: skipping ${ENV_FILE}"
+    fi
+    golden_snapshot_summary
+    exit 0
+  else
+    warn "VolumeSnapshot '${SNAP_NAME}' exists but is not ready. Deleting and recreating..."
+    if $DRY_RUN; then
+      warn "Dry-run: not deleting existing VolumeSnapshot; manifest below is what would be applied."
+    else
+      oc delete volumesnapshot "$SNAP_NAME" -n "$PVC_NAMESPACE"
+      sleep 2
+    fi
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# Step 6: create the VolumeSnapshot
+# ---------------------------------------------------------------------------
+info "Creating VolumeSnapshot '${SNAP_NAME}' from PVC '${PVC_NAME}'..."
+
+SNAP_MANIFEST=$(cat <<EOF
+apiVersion: snapshot.storage.k8s.io/v1
+kind: VolumeSnapshot
+metadata:
+  name: ${SNAP_NAME}
+  namespace: ${PVC_NAMESPACE}
+  labels:
+    app.kubernetes.io/managed-by: oadp-kubevirt-windows-test
+    app.kubernetes.io/created-by: 5_create-golden-snapshot.sh
+spec:
+  volumeSnapshotClassName: ${SNAP_CLASS}
+  source:
+    persistentVolumeClaimName: ${PVC_NAME}
+EOF
+)
+
+if $DRY_RUN; then
+  echo ""
+  echo "=== DRY RUN — VolumeSnapshot manifest that would be applied ==="
+  echo "$SNAP_MANIFEST"
+  echo "================================================================"
+  exit 0
+fi
+
+echo "$SNAP_MANIFEST" | oc apply -f -
+
+# ---------------------------------------------------------------------------
+# Step 7: wait for snapshot to become ready
+# ---------------------------------------------------------------------------
+info "Waiting for VolumeSnapshot to become readyToUse..."
+
+AWS_REGION=""
+if [[ -n "${SOURCE_AZ}" ]]; then
+  AWS_REGION="${SOURCE_AZ%[a-f]}"
+fi
+
+READY=false
+TIMEOUT=1800
+ELAPSED=0
+while [[ $ELAPSED -lt $TIMEOUT ]]; do
+  READY=$(oc get volumesnapshot "$SNAP_NAME" -n "$PVC_NAMESPACE" -o jsonpath='{.status.readyToUse}' 2>/dev/null || echo "false")
+  if [[ "$READY" == "true" ]]; then
+    break
+  fi
+
+  AWS_PROGRESS=""
+  if [[ -n "$AWS_REGION" ]] && command -v aws &>/dev/null; then
+    SNAP_CONTENT=$(oc get volumesnapshot "$SNAP_NAME" -n "$PVC_NAMESPACE" -o jsonpath='{.status.boundVolumeSnapshotContentName}' 2>/dev/null || true)
+    if [[ -n "$SNAP_CONTENT" ]]; then
+      SNAP_HANDLE=$(oc get volumesnapshotcontent "$SNAP_CONTENT" -o jsonpath='{.status.snapshotHandle}' 2>/dev/null || true)
+      if [[ -n "$SNAP_HANDLE" ]]; then
+        AWS_PROGRESS=$(aws ec2 describe-snapshots --snapshot-ids "$SNAP_HANDLE" \
+          --query 'Snapshots[0].Progress' --output text --region "$AWS_REGION" 2>/dev/null || true)
+      fi
+    fi
+  fi
+
+  if [[ -n "$AWS_PROGRESS" ]]; then
+    printf "\r  Waiting... (%ds / %ds) — EBS snapshot progress: %s" "$ELAPSED" "$TIMEOUT" "$AWS_PROGRESS"
+  else
+    printf "\r  Waiting... (%ds / %ds)" "$ELAPSED" "$TIMEOUT"
+  fi
+  sleep 5
+  ELAPSED=$((ELAPSED + 5))
+done
+
+if [[ "$READY" != "true" ]]; then
+  echo ""
+  die "VolumeSnapshot '${SNAP_NAME}' did not become ready within ${TIMEOUT}s."
+fi
+
+echo ""
+success "VolumeSnapshot '${SNAP_NAME}' is ready."
+
+SNAP_SIZE=$(oc get volumesnapshot "$SNAP_NAME" -n "$PVC_NAMESPACE" -o jsonpath='{.status.restoreSize}' 2>/dev/null || echo "unknown")
+info "Snapshot restore size: ${SNAP_SIZE}"
+
+# ---------------------------------------------------------------------------
+# Step 8: write env file
+# ---------------------------------------------------------------------------
+info "Writing ${ENV_FILE}..."
+cat > "$ENV_FILE" <<ENVEOF
+GOLDEN_SNAPSHOT_NAME=${SNAP_NAME}
+GOLDEN_SNAPSHOT_NS=${PVC_NAMESPACE}
+GOLDEN_SC=${SOURCE_SC}
+ENVEOF
+success "Env file written: ${ENV_FILE}"
+
+golden_snapshot_summary

--- a/scripts/manage-windows-volumesnapshot.sh
+++ b/scripts/manage-windows-volumesnapshot.sh
@@ -324,7 +324,7 @@ echo "$SNAP_MANIFEST" | oc apply -f -
 # ---------------------------------------------------------------------------
 # Create flow: wait for snapshot
 # ---------------------------------------------------------------------------
-wait_for_snapshot 1800 5 || die "VolumeSnapshot '${SNAP_NAME}' did not become ready within 1800s."
+wait_for_snapshot 7200 10 || die "VolumeSnapshot '${SNAP_NAME}' did not become ready within 7200s."
 success "VolumeSnapshot '${SNAP_NAME}' is ready."
 
 SNAP_SIZE=$(snap_field '{.status.restoreSize}' "unknown")


### PR DESCRIPTION
Take the upfromt cost of creating ebs snapshot of windows image. This reduces the initial time to provision windows from 30min to 2-3 min.  Allow for test cases to run sequentially in new namespaces for each test.  Same pattern as we would see with much smaller vm's like alpine.

A test suite can be configured to use the "windows-golden-snap" to provision and launch windows with in a couple minutes.     

Suggestion is that this pull request is closed and used as a template or example to add one more additional option for windows testing in ocptl that would take a volumesnapshot of the windows base image.  Perhaps even we can keep 1 known good volumesnap in storage and just copy it over to the write region ?  