### PR TITLE
Fix RHWA LAB remediation templates

### DIFF
--- a/internal/addon/definitions/rhwa.yaml
+++ b/internal/addon/definitions/rhwa.yaml
@@ -89,7 +89,7 @@ versions:
             spec:
               template:
                 spec:
-                  remediationStrategy: ResourceDeletion
+                  remediationStrategy: Automatic
           namespace: openshift-workload-availability
           dependsOn: [workload-availability-namespace, self-node-remediation]
 
@@ -101,10 +101,7 @@ versions:
             metadata:
               name: machine-deletion-template
               namespace: openshift-workload-availability
-            spec:
-              template:
-                spec:
-                  order: 0
+            spec: {}
           namespace: openshift-workload-availability
           dependsOn: [workload-availability-namespace, machine-deletion-remediation]
 


### PR DESCRIPTION
## Summary
- Change `remediationStrategy` from `ResourceDeletion` to `Automatic` in RHWA LAB SelfNodeRemediationTemplate (fixes #62)
- Remove unnecessary `spec.template.spec.order: 0` from MachineDeletionRemediationTemplate, using empty spec per [RHWA docs](https://docs.redhat.com/en/documentation/workload_availability_for_red_hat_openshift/4.22-0/html/remediation_fencing_and_maintenance/machine-deletion-remediation-operator-remediate-nodes#configuring-machine-deletion-remediation-operator_machine-deletion-remediation-operator-remediate-nodes) (fixes #63)

## Test plan
- [ ] Deploy RHWA addon on a test cluster and verify SelfNodeRemediationTemplate uses Automatic strategy
- [ ] Verify MachineDeletionRemediationTemplate creates successfully with empty spec