### PR TITLE
Add OCP 4.22 and Sunday to default work days

### DIFF
--- a/internal/api/handler_users.go
+++ b/internal/api/handler_users.go
@@ -192,7 +192,7 @@ func (h *UserHandler) Create(c echo.Context) error {
 		WorkHoursEnabled: false,
 		WorkHoursStart:   defaultStartTime,
 		WorkHoursEnd:     defaultEndTime,
-		WorkDays:         62, // Monday-Friday (binary: 0111110)
+		WorkDays:         63, // Sunday-Friday (binary: 0111111)
 		Active:           true,
 		CreatedAt:        time.Now(),
 		UpdatedAt:        time.Now(),

--- a/internal/profile/definitions/aws-rhwa-lab.yaml
+++ b/internal/profile/definitions/aws-rhwa-lab.yaml
@@ -12,7 +12,8 @@ openshiftVersions:
   allowlist:
   - '4.20'
   - '4.21'
-  default: '4.21'
+  - '4.22'
+  default: '4.22'
 regions:
   allowlist:
   - us-east-1

--- a/web/app/(dashboard)/clusters/new/page.tsx
+++ b/web/app/(dashboard)/clusters/new/page.tsx
@@ -83,7 +83,7 @@ export default function NewClusterPage() {
       work_hours_enabled: user?.work_hours_enabled || false,
       work_hours_start: user?.work_hours?.start_time || "09:00",
       work_hours_end: user?.work_hours?.end_time || "17:00",
-      work_days: user?.work_hours?.work_days || ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday"],
+      work_days: user?.work_hours?.work_days || ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday"],
     },
   });
 

--- a/web/app/(dashboard)/profile/page.tsx
+++ b/web/app/(dashboard)/profile/page.tsx
@@ -76,7 +76,7 @@ export default function ProfilePage() {
       work_hours_enabled: user?.work_hours_enabled || false,
       work_hours_start: user?.work_hours?.start_time || "09:00",
       work_hours_end: user?.work_hours?.end_time || "17:00",
-      work_days: user?.work_hours?.work_days || ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday"],
+      work_days: user?.work_hours?.work_days || ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday"],
     },
   });
 


### PR DESCRIPTION
## Summary
- Add OCP 4.22 to the RHWA LAB profile's allowed versions and set as default (fixes #65)
- Include Sunday in default work days for cluster creation and user profiles, supporting regions where Sunday is a work day (fixes #64)

## Test plan
- [ ] Verify OCP 4.22 appears in version dropdown for RHWA LAB profile
- [ ] Verify new users get Sunday included in their default work days
- [ ] Verify cluster creation form defaults include Sunday