### PR TITLE
Add Asia/Jerusalem timezone to profile dropdown

### DIFF
--- a/web/app/(dashboard)/profile/page.tsx
+++ b/web/app/(dashboard)/profile/page.tsx
@@ -37,6 +37,7 @@ const TIMEZONES = [
   { value: "Europe/Paris", label: "Paris (CET/CEST)" },
   { value: "Europe/Berlin", label: "Berlin (CET/CEST)" },
   { value: "Europe/Moscow", label: "Moscow (MSK)" },
+  { value: "Asia/Jerusalem", label: "Jerusalem (IST/IDT)" },
   { value: "Asia/Dubai", label: "Dubai (GST)" },
   { value: "Asia/Kolkata", label: "India (IST)" },
   { value: "Asia/Singapore", label: "Singapore (SGT)" },


### PR DESCRIPTION
## Summary
- Adds `Asia/Jerusalem` (IST/IDT, UTC+2/+3) to the timezone selection dropdown on the profile page
- Enables Israeli associates to set the correct timezone for work-hours cluster hibernation enforcement

Relates to #64

## Test plan
- [ ] Open Profile/Settings page
- [ ] Verify "Jerusalem (IST/IDT)" appears in the timezone dropdown between Moscow and Dubai
- [ ] Select it and save — confirm it persists on page reload