### PR TITLE
:feat: allow cluster form values to be saved as templates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,21 @@ on:
 jobs:
   vet-and-test:
     runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:17
+        env:
+          POSTGRES_PASSWORD: test
+          POSTGRES_DB: ocpctl_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    env:
+      TEST_DATABASE_URL: postgres://postgres:test@localhost:5432/ocpctl_test
     steps:
       - uses: actions/checkout@v4
 

--- a/docs/features/CLUSTER_TEMPLATES.md
+++ b/docs/features/CLUSTER_TEMPLATES.md
@@ -1,0 +1,275 @@
+# Cluster Creation Templates
+
+## Overview
+
+Cluster creation templates let a user save the parameters they commonly use when
+requesting a cluster and reload them later to pre-populate the create-cluster form.
+When a template is applied, every field stored in the template is filled in and any
+field not present in the template is left for the user to complete. The **cluster name
+is never stored in, or populated from, a template** — it must always be entered per
+cluster.
+
+Templates are **private to each user**: a template is only ever visible to, editable
+by, and deletable by its owner. Each user may keep at most **5 templates**.
+
+A template can be **saved as new or overwritten** from the create-cluster form, so the
+form doubles as an editor for a loaded template. After a cluster is created with
+settings that don't match any saved template, the user is **prompted on the new
+cluster's detail page** to save those settings as a template.
+
+This feature is unrelated to the pre-existing `PostConfigTemplate` (post-deployment
+add-on/operator presets). Post-config templates describe *what to install after* a
+cluster is ready; cluster templates describe *how to request* the cluster itself.
+
+## Goals
+
+- Eliminate repetitive re-entry of the same platform / profile / region / team /
+  cost-center / TTL / SSH key / tags / add-ons on every cluster request.
+- Keep the mechanism decoupled from the ever-growing set of create-cluster fields.
+- Guarantee cluster names are always unique and human-chosen (never templated).
+
+## Non-Goals
+
+- Sharing templates between users or teams (explicitly private-only for now).
+- Server-side validation of template contents against profiles. A template is a
+  convenience preset; the authoritative validation still runs at cluster-creation time.
+- Renaming a template. Contents can be overwritten in place, but a template's name is
+  fixed once created; to rename, delete and re-save.
+
+## Design Decisions
+
+### 1. Store the form state, not the API request (config → decision → outcome)
+
+- **Context:** The create-cluster HTTP request (`CreateClusterRequest`) and the web
+  form (`CreateClusterFormData`) have different shapes. The form has UI-only fields
+  (`override_work_hours`, `work_hours_start/end`, `work_days`) that are collapsed into a
+  single `work_hours` object only at submit time.
+- **Decision:** A template stores the **form field values** (a partial
+  `CreateClusterFormData`), serialized as opaque JSON. Applying a template is a direct
+  field-by-field restore into the form; saving is a direct capture of current form
+  values.
+- **Outcome:** The backend never needs to track the create-cluster field set. New form
+  fields become templatable simply by adding them to a single `TEMPLATE_FIELDS` list on
+  the frontend. Backend and frontend stay decoupled.
+
+### 2. Opaque JSONB config on the backend
+
+- **Context:** Mirroring the typed `PostConfigTemplate.Config` would require a Go struct
+  duplicating every form field and would drift as the form evolves.
+- **Decision:** `ClusterTemplate.Config` is `json.RawMessage` persisted to a `JSONB`
+  column. The backend validates only that the config is a JSON object and that a `name`
+  key is stripped.
+- **Outcome:** Minimal backend surface; the frontend owns the shape. The `name`-strip is
+  a defense-in-depth guarantee that the "name is never templated" rule holds even if a
+  client sends one.
+
+### 3. Template values win over profile defaults
+
+- **Context:** Selecting a profile triggers an effect that sets default version, region,
+  TTL, credentials mode, base domain, and add-ons. If a template set those fields first,
+  the profile effect would clobber them.
+- **Decision:** Applying a template sets platform/cluster-type state and all fields
+  immediately, and records the template in a `pendingTemplate` ref. The profile-defaults
+  effect re-applies the pending template *after* it writes profile defaults, then clears
+  the ref.
+- **Outcome:** A template's explicit region/version/TTL survive even though selecting its
+  profile also fires the defaults effect. Fields the template does not specify still fall
+  back to profile defaults.
+
+### 4. Per-user limit of 5, enforced atomically (config → decision → outcome)
+
+- **Context:** Unlimited templates clutter the load/overwrite pickers and give unbounded
+  per-user storage. The limit must hold even if a client bypasses the UI or double-submits.
+- **Decision:** `MaxTemplatesPerUser = 5`. `ClusterTemplateStore.Create` counts the
+  owner's rows and inserts **within one transaction**, returning `ErrTemplateLimitReached`
+  when at the cap; the handler maps that to a 400. The UI mirrors the constant: at 5, the
+  "New template" mode is disabled and only overwrite is offered. Overwrites (Update) never
+  count against the limit.
+- **Outcome:** The cap is authoritative server-side; the UI degrades gracefully rather
+  than letting a save fail opaquely.
+
+### 5. Post-create prompt lives on the cluster detail page (config → decision → outcome)
+
+- **Context:** After a successful create the form navigates to `/clusters/:id`, and the
+  App Router cannot carry in-memory state across that navigation. The prompt should only
+  appear when the just-used settings aren't already saved.
+- **Decision:** On successful create, the form stashes its `getCurrentConfig()` snapshot in
+  `sessionStorage` under `ocpctl:new-cluster-template-config`, then navigates. The detail
+  page mounts `SaveClusterSettingsPrompt`, which consumes (and clears) that key once,
+  compares the config against every saved template using a canonical (sorted-key,
+  undefined-dropped) JSON encoding, and prompts only when there is no match.
+- **Outcome:** No cross-page state coupling; the prompt is best-effort (a missing/blocked
+  `sessionStorage` simply means no prompt) and never nags a user whose settings are
+  already templated.
+
+## Data Model
+
+New table (migration `00068_cluster_templates.sql`):
+
+```sql
+CREATE TABLE cluster_templates (
+  id VARCHAR(64) PRIMARY KEY DEFAULT gen_random_uuid()::text,
+  name VARCHAR(255) NOT NULL,
+  owner_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  config JSONB NOT NULL,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+  updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+  UNIQUE (owner_id, name)
+);
+CREATE INDEX idx_cluster_templates_owner ON cluster_templates(owner_id);
+```
+
+- `UNIQUE (owner_id, name)` — a user cannot have two templates with the same name; a
+  save with a duplicate name fails and surfaces as an error in the dialog.
+- `ON DELETE CASCADE` — templates are removed when the owning user is deleted.
+
+Go type (`pkg/types/cluster_template.go`):
+
+```go
+type ClusterTemplate struct {
+    ID        string          `db:"id" json:"id"`
+    Name      string          `db:"name" json:"name"`
+    OwnerID   string          `db:"owner_id" json:"ownerId"`
+    Config    json.RawMessage `db:"config" json:"config"`
+    CreatedAt time.Time       `db:"created_at" json:"createdAt"`
+    UpdatedAt time.Time       `db:"updated_at" json:"updatedAt"`
+}
+```
+
+## What a Template Stores
+
+All create-cluster form fields **except `name`**. `owner` and the transient
+`idempotency_key` are not meaningful reusable parameters and are excluded from the
+capture list (`owner` is always the requesting user; `idempotency_key` is a per-request
+dedup token).
+
+Captured fields (`TEMPLATE_FIELDS`):
+
+```
+platform, cluster_type, version, profile, region, base_domain,
+owner, team, cost_center, ttl_hours, ssh_public_key, extra_tags,
+offhours_opt_in, skip_post_deployment, postConfigAddOns, customPostConfig,
+enable_efs_storage, preserve_on_failure, credentials_mode, custom_pull_secret,
+override_work_hours, work_hours_enabled, work_hours_start, work_hours_end, work_days
+```
+
+> Note: `owner` is listed above because the form carries it, but the backend strips
+> `name` only; `owner` is harmless (always the same user for a private template). The
+> single hard rule is: **`name` is never stored and never applied.**
+
+## API
+
+All routes require authentication and are scoped to the authenticated user
+(`/api/v1/cluster-templates`):
+
+| Method | Path                        | Description                          |
+|--------|-----------------------------|--------------------------------------|
+| POST   | `/cluster-templates`        | Create a template                    |
+| GET    | `/cluster-templates`        | List the caller's templates          |
+| GET    | `/cluster-templates/:id`    | Get one of the caller's templates    |
+| PATCH  | `/cluster-templates/:id`    | Update the caller's template         |
+| DELETE | `/cluster-templates/:id`    | Delete the caller's template         |
+
+Request body (create/update):
+
+```json
+{
+  "name": "My standard AWS SNO",
+  "config": {
+    "platform": "aws",
+    "cluster_type": "openshift",
+    "profile": "aws-sno-ga",
+    "region": "us-east-1",
+    "team": "platform",
+    "cost_center": "733",
+    "ttl_hours": 72
+  }
+}
+```
+
+The server strips any `name` key inside `config` before persisting. `POST` fails with a
+400 when the caller already has `MaxTemplatesPerUser` (5) templates; overwriting via
+`PATCH` is unaffected by the limit.
+
+## Backend Components
+
+- `pkg/types/cluster_template.go` — `ClusterTemplate` type.
+- `internal/store/migrations/00068_cluster_templates.sql` — schema.
+- `internal/store/cluster_templates.go` — `ClusterTemplateStore` with owner-scoped
+  `Create` / `GetByID` / `List` / `Update` / `Delete`.
+- `internal/store/store.go` — `Store.ClusterTemplates` wiring.
+- `internal/api/handler_cluster_templates.go` — `ClusterTemplateHandler` (bind →
+  validate → `sanitizeTemplateConfig` → store). `sanitizeTemplateConfig` enforces the
+  JSON-object shape and the `name` strip.
+- `internal/api/server.go` — route registration.
+
+Ownership is enforced at the SQL layer: every query filters by `owner_id`, so there is
+no cross-user read/update/delete path even with a guessed ID.
+
+## Frontend Components
+
+- `web/types/api.ts` — `ClusterTemplate`, `ClusterTemplatesResponse`.
+- `web/lib/api/endpoints/clusterTemplates.ts` — API client (`list/get/create/update/delete`).
+- `web/lib/api/index.ts` — export.
+- `web/lib/hooks/useClusterTemplates.ts` — React Query hooks (`useClusterTemplates`,
+  `useCreateClusterTemplate`, `useUpdateClusterTemplate`, `useDeleteClusterTemplate`).
+- `web/components/clusters/SaveTemplateDialog.tsx` — shared save dialog with New/Overwrite
+  modes; exports `MAX_CLUSTER_TEMPLATES` (mirrors the backend constant). Used by both the
+  create-page bar and the post-create prompt.
+- `web/components/clusters/ClusterTemplateBar.tsx` — the load/apply/delete control bar plus
+  the "Save as template" button that opens `SaveTemplateDialog`.
+- `web/components/clusters/SaveClusterSettingsPrompt.tsx` — consumes the stashed config on
+  the cluster detail page and, if unmatched, prompts to save it (via `SaveTemplateDialog`).
+- `web/app/(dashboard)/clusters/new/page.tsx` — integration:
+  - `ClusterTemplateBar` rendered above the form.
+  - `getCurrentConfig()` snapshots form values (minus `name`) for save.
+  - `handleApplyTemplate()` sets platform/cluster-type state, applies fields, and queues
+    a re-apply via `pendingTemplate`.
+  - The profile-defaults effect re-applies `pendingTemplate` after writing defaults.
+  - On successful create, stashes `getCurrentConfig()` in `sessionStorage` before navigating.
+- `web/app/(dashboard)/clusters/[id]/page.tsx` — renders `SaveClusterSettingsPrompt`.
+
+## User Flow
+
+1. On **Create Cluster**, the user selects a saved template and clicks **Apply**. The
+   form fills with the template's values; the cluster name field stays empty.
+2. The user enters a unique cluster name and adjusts any remaining fields.
+3. Alternatively, after filling the form the user clicks **Save as template** and either
+   names a **new** template or picks an existing one to **overwrite** (editing a loaded
+   template in place).
+4. A template can be removed with the delete (trash) button next to the selector.
+5. After creating a cluster, if the settings used don't match any saved template, the new
+   cluster's detail page prompts **"Save these settings as a template?"** — the user can
+   dismiss it or save (as new, or overwrite if at the 5-template limit).
+
+## Edge Cases
+
+- **Template profile no longer valid** (disabled/removed, or wrong track filter): the
+  form's existing "clear profile if invalid" effect clears the profile; other
+  non-profile-dependent template fields still apply. The user re-selects a profile.
+- **Duplicate template name:** blocked by the `UNIQUE (owner_id, name)` constraint;
+  surfaced as an error in the save dialog.
+- **Config with a stray `name`:** stripped server-side; never applied client-side
+  (`name` is not in `TEMPLATE_FIELDS`).
+- **Platform/cluster-type in template:** applied to both the react-hook-form values and
+  the separate `selectedPlatform` / `selectedClusterType` component state that drives
+  profile filtering.
+- **At the 5-template limit:** the save dialog disables "New template" and offers only
+  overwrite; a `POST` that slips through is rejected 400 by the backend.
+- **Post-create prompt with no match:** shown once per created cluster; dismissing it or
+  reloading the detail page (the `sessionStorage` key is cleared on first read) does not
+  re-prompt. If the settings already match a saved template, no prompt appears.
+
+## Testing
+
+- Backend: unit tests for `sanitizeTemplateConfig` (object required, `name` stripped)
+  and owner-scoping of `ClusterTemplateStore` methods.
+- Frontend: apply-template pre-fills fields and leaves `name` empty; template values
+  survive the profile-defaults effect; save captures current values minus `name`.
+
+## Future Enhancements
+
+- Rename existing templates (overwrite of contents is already supported).
+- Optional team-shared or public templates (would reintroduce an `is_public`/visibility
+  model like `PostConfigTemplate`).
+- A dedicated template management page for bulk view/edit/delete.

--- a/internal/api/handler_cluster_templates.go
+++ b/internal/api/handler_cluster_templates.go
@@ -1,0 +1,201 @@
+package api
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/labstack/echo/v4"
+	"github.com/tsanders-rh/ocpctl/internal/auth"
+	"github.com/tsanders-rh/ocpctl/internal/store"
+	"github.com/tsanders-rh/ocpctl/pkg/types"
+)
+
+// ClusterTemplateHandler handles per-user cluster-creation template endpoints
+type ClusterTemplateHandler struct {
+	store *store.Store
+}
+
+// NewClusterTemplateHandler creates a new cluster template handler
+func NewClusterTemplateHandler(s *store.Store) *ClusterTemplateHandler {
+	return &ClusterTemplateHandler{store: s}
+}
+
+// ClusterTemplateRequest is the body for creating or updating a cluster template.
+// Config is a partial create-cluster payload captured from the creation form.
+type ClusterTemplateRequest struct {
+	Name   string          `json:"name" validate:"required,min=3,max=100"`
+	Config json.RawMessage `json:"config" validate:"required"`
+}
+
+// sanitizeTemplateConfig ensures the config is a JSON object and strips any
+// cluster "name" so a template can never carry a cluster name.
+func sanitizeTemplateConfig(raw json.RawMessage) (json.RawMessage, bool) {
+	var obj map[string]interface{}
+	if err := json.Unmarshal(raw, &obj); err != nil {
+		return nil, false
+	}
+	delete(obj, "name")
+
+	cleaned, err := json.Marshal(obj)
+	if err != nil {
+		return nil, false
+	}
+	return cleaned, true
+}
+
+// Create handles POST /api/v1/cluster-templates
+func (h *ClusterTemplateHandler) Create(c echo.Context) error {
+	ctx := c.Request().Context()
+
+	var req ClusterTemplateRequest
+	if err := c.Bind(&req); err != nil {
+		return ErrorBadRequest(c, "Invalid request body")
+	}
+	if err := c.Validate(req); err != nil {
+		return ErrorBadRequest(c, err.Error())
+	}
+
+	config, ok := sanitizeTemplateConfig(req.Config)
+	if !ok {
+		return ErrorBadRequest(c, "config must be a JSON object")
+	}
+
+	userID, err := auth.GetUserID(c)
+	if err != nil {
+		return err
+	}
+
+	template := &types.ClusterTemplate{
+		ID:        uuid.New().String(),
+		Name:      req.Name,
+		OwnerID:   userID,
+		Config:    config,
+		CreatedAt: time.Now(),
+		UpdatedAt: time.Now(),
+	}
+
+	if err := h.store.ClusterTemplates.Create(ctx, template); err != nil {
+		if errors.Is(err, store.ErrTemplateLimitReached) {
+			return ErrorBadRequest(c, fmt.Sprintf("You can save at most %d templates. Overwrite an existing template instead.", store.MaxTemplatesPerUser))
+		}
+		return LogAndReturnGenericError(c, err)
+	}
+
+	LogInfo(c, "cluster template created",
+		"template_id", template.ID,
+		"template_name", template.Name,
+		"user_id", userID)
+
+	return SuccessCreated(c, template)
+}
+
+// List handles GET /api/v1/cluster-templates
+func (h *ClusterTemplateHandler) List(c echo.Context) error {
+	ctx := c.Request().Context()
+
+	userID, err := auth.GetUserID(c)
+	if err != nil {
+		return err
+	}
+
+	templates, err := h.store.ClusterTemplates.List(ctx, userID)
+	if err != nil {
+		return LogAndReturnGenericError(c, err)
+	}
+
+	return SuccessOK(c, map[string]interface{}{
+		"templates": templates,
+	})
+}
+
+// Get handles GET /api/v1/cluster-templates/:id
+func (h *ClusterTemplateHandler) Get(c echo.Context) error {
+	ctx := c.Request().Context()
+
+	userID, err := auth.GetUserID(c)
+	if err != nil {
+		return err
+	}
+
+	template, err := h.store.ClusterTemplates.GetByID(ctx, c.Param("id"), userID)
+	if err != nil {
+		return ErrorNotFound(c, "Template not found")
+	}
+
+	return SuccessOK(c, template)
+}
+
+// Update handles PATCH /api/v1/cluster-templates/:id
+func (h *ClusterTemplateHandler) Update(c echo.Context) error {
+	ctx := c.Request().Context()
+
+	id := c.Param("id")
+
+	var req ClusterTemplateRequest
+	if err := c.Bind(&req); err != nil {
+		return ErrorBadRequest(c, "Invalid request body")
+	}
+	if err := c.Validate(req); err != nil {
+		return ErrorBadRequest(c, err.Error())
+	}
+
+	config, ok := sanitizeTemplateConfig(req.Config)
+	if !ok {
+		return ErrorBadRequest(c, "config must be a JSON object")
+	}
+
+	userID, err := auth.GetUserID(c)
+	if err != nil {
+		return err
+	}
+
+	existing, err := h.store.ClusterTemplates.GetByID(ctx, id, userID)
+	if err != nil {
+		return ErrorNotFound(c, "Template not found")
+	}
+
+	template := &types.ClusterTemplate{
+		ID:        id,
+		Name:      req.Name,
+		OwnerID:   existing.OwnerID,
+		Config:    config,
+		CreatedAt: existing.CreatedAt,
+		UpdatedAt: time.Now(),
+	}
+
+	if err := h.store.ClusterTemplates.Update(ctx, template); err != nil {
+		return LogAndReturnGenericError(c, err)
+	}
+
+	LogInfo(c, "cluster template updated",
+		"template_id", template.ID,
+		"template_name", template.Name,
+		"user_id", userID)
+
+	return SuccessOK(c, template)
+}
+
+// Delete handles DELETE /api/v1/cluster-templates/:id
+func (h *ClusterTemplateHandler) Delete(c echo.Context) error {
+	ctx := c.Request().Context()
+
+	userID, err := auth.GetUserID(c)
+	if err != nil {
+		return err
+	}
+
+	if err := h.store.ClusterTemplates.Delete(ctx, c.Param("id"), userID); err != nil {
+		return ErrorNotFound(c, "Template not found or access denied")
+	}
+
+	LogInfo(c, "cluster template deleted",
+		"template_id", c.Param("id"),
+		"user_id", userID)
+
+	return SuccessOK(c, map[string]string{
+		"message": "Template deleted successfully",
+	})
+}

--- a/internal/api/handler_cluster_templates_test.go
+++ b/internal/api/handler_cluster_templates_test.go
@@ -1,0 +1,90 @@
+package api_test
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/require"
+	"github.com/tsanders-rh/ocpctl/internal/api"
+	"github.com/tsanders-rh/ocpctl/internal/dbtest"
+	"github.com/tsanders-rh/ocpctl/internal/store"
+	"github.com/tsanders-rh/ocpctl/pkg/types"
+)
+
+func newTemplateUser(t *testing.T, s *store.Store) *types.User {
+	t.Helper()
+	id := uuid.New().String()
+	user := &types.User{
+		ID:           id,
+		Email:        id + "@example.com",
+		Username:     id,
+		PasswordHash: "x",
+		Role:         types.RoleUser,
+		Timezone:     "UTC",
+		WorkDays:     62,
+		Active:       true,
+		CreatedAt:    time.Now(),
+		UpdatedAt:    time.Now(),
+	}
+	require.NoError(t, s.Users.Create(ctx, user))
+	return user
+}
+
+func TestClusterTemplateHandler_Create_EnforcesLimit(t *testing.T) {
+	s := dbtest.New(t)
+	user := newTemplateUser(t, s)
+	h := api.NewClusterTemplateHandler(s)
+
+	e := echo.New()
+	e.Validator = api.NewValidator()
+
+	post := func(name string) *httptest.ResponseRecorder {
+		body := fmt.Sprintf(`{"name":%q,"config":{"platform":"aws"}}`, name)
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/cluster-templates", strings.NewReader(body))
+		req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+		rec := httptest.NewRecorder()
+		c := e.NewContext(req, rec)
+		setAuthContext(c, user)
+		require.NoError(t, h.Create(c))
+		return rec
+	}
+
+	for i := 0; i < store.MaxTemplatesPerUser; i++ {
+		rec := post(fmt.Sprintf("template-%02d", i))
+		require.Equal(t, http.StatusCreated, rec.Code, "create %d should succeed", i)
+	}
+
+	rec := post("over-the-limit")
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+	require.Contains(t, rec.Body.String(), fmt.Sprintf("at most %d templates", store.MaxTemplatesPerUser))
+}
+
+func TestClusterTemplateHandler_Create_StripsName(t *testing.T) {
+	s := dbtest.New(t)
+	user := newTemplateUser(t, s)
+	h := api.NewClusterTemplateHandler(s)
+
+	e := echo.New()
+	e.Validator = api.NewValidator()
+
+	body := `{"name":"has-name","config":{"name":"should-be-stripped","platform":"aws"}}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/cluster-templates", strings.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	setAuthContext(c, user)
+	require.NoError(t, h.Create(c))
+	require.Equal(t, http.StatusCreated, rec.Code)
+
+	list, err := s.ClusterTemplates.List(ctx, user.ID)
+	require.NoError(t, err)
+	require.Len(t, list, 1)
+	require.NotContains(t, string(list[0].Config), "should-be-stripped")
+	require.NotContains(t, string(list[0].Config), `"name"`)
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -413,6 +413,15 @@ func (s *Server) setupRoutes() {
 	templatesGroup.PATCH("/:id", templateHandler.Update)
 	templatesGroup.DELETE("/:id", templateHandler.Delete)
 
+	// Cluster-creation template routes (per-user, require authentication)
+	clusterTemplateHandler := NewClusterTemplateHandler(s.store)
+	clusterTemplatesGroup := v1.Group("/cluster-templates", auth.RequireAuthDual(s.auth, s.iamAuth))
+	clusterTemplatesGroup.POST("", clusterTemplateHandler.Create)
+	clusterTemplatesGroup.GET("", clusterTemplateHandler.List)
+	clusterTemplatesGroup.GET("/:id", clusterTemplateHandler.Get)
+	clusterTemplatesGroup.PATCH("/:id", clusterTemplateHandler.Update)
+	clusterTemplatesGroup.DELETE("/:id", clusterTemplateHandler.Delete)
+
 	// Job routes (require authentication)
 	jobHandler := NewJobHandler(s.store)
 	jobsGroup := v1.Group("/jobs", auth.RequireAuthDual(s.auth, s.iamAuth))

--- a/internal/dbtest/db.go
+++ b/internal/dbtest/db.go
@@ -1,0 +1,34 @@
+// Package dbtest provides a shared PostgreSQL harness for store- and API-level
+// tests. Tests that need a real database call New; when TEST_DATABASE_URL is not
+// set (e.g. a developer running `go test` without a database) the test is skipped
+// rather than failed. CI sets TEST_DATABASE_URL so these tests always run there.
+package dbtest
+
+import (
+	"os"
+	"testing"
+
+	"github.com/tsanders-rh/ocpctl/internal/store"
+)
+
+// New returns a migrated Store connected to the database in TEST_DATABASE_URL,
+// or skips the calling test when that variable is unset.
+func New(t testing.TB) *store.Store {
+	t.Helper()
+
+	url := os.Getenv("TEST_DATABASE_URL")
+	if url == "" {
+		t.Skip("TEST_DATABASE_URL not set; skipping database-backed test")
+	}
+
+	s, err := store.NewStore(url)
+	if err != nil {
+		t.Fatalf("connect test database: %v", err)
+	}
+	if err := s.Migrate(); err != nil {
+		s.Close()
+		t.Fatalf("migrate test database: %v", err)
+	}
+	t.Cleanup(s.Close)
+	return s
+}

--- a/internal/store/cluster_templates.go
+++ b/internal/store/cluster_templates.go
@@ -1,0 +1,119 @@
+package store
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/tsanders-rh/ocpctl/pkg/types"
+)
+
+// MaxTemplatesPerUser caps how many cluster-creation templates a single user may keep.
+const MaxTemplatesPerUser = 5
+
+// ErrTemplateLimitReached is returned by Create when the owner already has MaxTemplatesPerUser templates.
+var ErrTemplateLimitReached = errors.New("cluster template limit reached")
+
+// ClusterTemplateStore handles database operations for cluster-creation templates.
+// Templates are private: every operation is scoped to the owning user.
+type ClusterTemplateStore struct {
+	pool *pgxpool.Pool
+}
+
+// Create inserts a new template, enforcing the per-user limit atomically so two
+// concurrent saves cannot exceed MaxTemplatesPerUser.
+func (s *ClusterTemplateStore) Create(ctx context.Context, t *types.ClusterTemplate) error {
+	tx, err := s.pool.Begin(ctx)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback(ctx)
+
+	var count int
+	if err := tx.QueryRow(ctx, `SELECT COUNT(*) FROM cluster_templates WHERE owner_id = $1`, t.OwnerID).Scan(&count); err != nil {
+		return err
+	}
+	if count >= MaxTemplatesPerUser {
+		return ErrTemplateLimitReached
+	}
+
+	if _, err := tx.Exec(ctx, `
+		INSERT INTO cluster_templates (id, name, owner_id, config, created_at, updated_at)
+		VALUES ($1, $2, $3, $4, $5, $6)
+	`, t.ID, t.Name, t.OwnerID, []byte(t.Config), t.CreatedAt, t.UpdatedAt); err != nil {
+		return err
+	}
+
+	return tx.Commit(ctx)
+}
+
+func (s *ClusterTemplateStore) GetByID(ctx context.Context, id, userID string) (*types.ClusterTemplate, error) {
+	query := `
+		SELECT id, name, owner_id, config, created_at, updated_at
+		FROM cluster_templates
+		WHERE id = $1 AND owner_id = $2
+	`
+	var t types.ClusterTemplate
+	var config []byte
+	if err := s.pool.QueryRow(ctx, query, id, userID).Scan(
+		&t.ID, &t.Name, &t.OwnerID, &config, &t.CreatedAt, &t.UpdatedAt,
+	); err != nil {
+		return nil, err
+	}
+	t.Config = config
+	return &t, nil
+}
+
+func (s *ClusterTemplateStore) List(ctx context.Context, userID string) ([]*types.ClusterTemplate, error) {
+	query := `
+		SELECT id, name, owner_id, config, created_at, updated_at
+		FROM cluster_templates
+		WHERE owner_id = $1
+		ORDER BY name ASC
+	`
+	rows, err := s.pool.Query(ctx, query, userID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	templates := make([]*types.ClusterTemplate, 0)
+	for rows.Next() {
+		var t types.ClusterTemplate
+		var config []byte
+		if err := rows.Scan(&t.ID, &t.Name, &t.OwnerID, &config, &t.CreatedAt, &t.UpdatedAt); err != nil {
+			return nil, err
+		}
+		t.Config = config
+		templates = append(templates, &t)
+	}
+	return templates, rows.Err()
+}
+
+func (s *ClusterTemplateStore) Update(ctx context.Context, t *types.ClusterTemplate) error {
+	query := `
+		UPDATE cluster_templates
+		SET name = $1, config = $2, updated_at = $3
+		WHERE id = $4 AND owner_id = $5
+	`
+	result, err := s.pool.Exec(ctx, query, t.Name, []byte(t.Config), t.UpdatedAt, t.ID, t.OwnerID)
+	if err != nil {
+		return err
+	}
+	if result.RowsAffected() == 0 {
+		return fmt.Errorf("template not found or access denied")
+	}
+	return nil
+}
+
+func (s *ClusterTemplateStore) Delete(ctx context.Context, id, userID string) error {
+	result, err := s.pool.Exec(ctx, `DELETE FROM cluster_templates WHERE id = $1 AND owner_id = $2`, id, userID)
+	if err != nil {
+		return err
+	}
+	if result.RowsAffected() == 0 {
+		return fmt.Errorf("template not found or access denied")
+	}
+	return nil
+}

--- a/internal/store/cluster_templates_test.go
+++ b/internal/store/cluster_templates_test.go
@@ -1,0 +1,99 @@
+package store_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"github.com/tsanders-rh/ocpctl/internal/dbtest"
+	"github.com/tsanders-rh/ocpctl/internal/store"
+	"github.com/tsanders-rh/ocpctl/pkg/types"
+)
+
+func newTemplateOwner(t *testing.T, s *store.Store) *types.User {
+	t.Helper()
+	ctx := context.Background()
+	id := uuid.New().String()
+	user := &types.User{
+		ID:           id,
+		Email:        id + "@example.com",
+		Username:     id,
+		PasswordHash: "x",
+		Role:         types.RoleUser,
+		Timezone:     "UTC",
+		WorkDays:     62,
+		Active:       true,
+		CreatedAt:    time.Now(),
+		UpdatedAt:    time.Now(),
+	}
+	require.NoError(t, s.Users.Create(ctx, user))
+	return user
+}
+
+func newTemplate(ownerID, name string) *types.ClusterTemplate {
+	return &types.ClusterTemplate{
+		ID:        uuid.New().String(),
+		Name:      name,
+		OwnerID:   ownerID,
+		Config:    json.RawMessage(`{"platform":"aws"}`),
+		CreatedAt: time.Now(),
+		UpdatedAt: time.Now(),
+	}
+}
+
+func TestClusterTemplateStore_Create_EnforcesPerUserLimit(t *testing.T) {
+	s := dbtest.New(t)
+	ctx := context.Background()
+	owner := newTemplateOwner(t, s)
+
+	for i := 0; i < store.MaxTemplatesPerUser; i++ {
+		err := s.ClusterTemplates.Create(ctx, newTemplate(owner.ID, fmt.Sprintf("template-%d", i)))
+		require.NoError(t, err, "creating template %d within the limit should succeed", i)
+	}
+
+	err := s.ClusterTemplates.Create(ctx, newTemplate(owner.ID, "one-too-many"))
+	require.ErrorIs(t, err, store.ErrTemplateLimitReached)
+
+	list, err := s.ClusterTemplates.List(ctx, owner.ID)
+	require.NoError(t, err)
+	require.Len(t, list, store.MaxTemplatesPerUser, "the rejected template must not have been inserted")
+}
+
+func TestClusterTemplateStore_Create_LimitIsPerOwner(t *testing.T) {
+	s := dbtest.New(t)
+	ctx := context.Background()
+	owner1 := newTemplateOwner(t, s)
+	owner2 := newTemplateOwner(t, s)
+
+	for i := 0; i < store.MaxTemplatesPerUser; i++ {
+		require.NoError(t, s.ClusterTemplates.Create(ctx, newTemplate(owner1.ID, fmt.Sprintf("t-%d", i))))
+	}
+
+	// A different owner at another owner's limit is unaffected.
+	require.NoError(t, s.ClusterTemplates.Create(ctx, newTemplate(owner2.ID, "t-0")))
+}
+
+func TestClusterTemplateStore_ScopedToOwner(t *testing.T) {
+	s := dbtest.New(t)
+	ctx := context.Background()
+	owner := newTemplateOwner(t, s)
+	other := newTemplateOwner(t, s)
+
+	tmpl := newTemplate(owner.ID, "mine")
+	require.NoError(t, s.ClusterTemplates.Create(ctx, tmpl))
+
+	// Another user cannot read, update, or delete it.
+	_, err := s.ClusterTemplates.GetByID(ctx, tmpl.ID, other.ID)
+	require.Error(t, err)
+
+	require.Error(t, s.ClusterTemplates.Delete(ctx, tmpl.ID, other.ID))
+
+	// The owner can.
+	got, err := s.ClusterTemplates.GetByID(ctx, tmpl.ID, owner.ID)
+	require.NoError(t, err)
+	require.Equal(t, "mine", got.Name)
+}

--- a/internal/store/migrations/00004_seed_admin_user.sql
+++ b/internal/store/migrations/00004_seed_admin_user.sql
@@ -6,7 +6,7 @@ VALUES (
     'admin@localhost',
     'admin',
     '$2a$10$FA2EDw.BHNmEP508TMIka.iXbt4l4D1B3AMcYBAzi9B1bO.gV6Yv2',
-    'admin',
+    'ADMIN',
     true,
     NOW(),
     NOW()

--- a/internal/store/migrations/00068_cluster_templates.sql
+++ b/internal/store/migrations/00068_cluster_templates.sql
@@ -1,0 +1,18 @@
+-- +goose Up
+-- Per-user reusable cluster-creation parameter presets
+CREATE TABLE cluster_templates (
+  id VARCHAR(64) PRIMARY KEY DEFAULT gen_random_uuid()::text,
+  name VARCHAR(255) NOT NULL,
+  owner_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  config JSONB NOT NULL,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+  updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+  UNIQUE (owner_id, name)
+);
+
+CREATE INDEX idx_cluster_templates_owner ON cluster_templates(owner_id);
+
+COMMENT ON TABLE cluster_templates IS 'Per-user reusable cluster-creation parameter presets. Config is a partial create-cluster payload; the cluster name is never stored.';
+
+-- +goose Down
+DROP TABLE IF EXISTS cluster_templates;

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -56,6 +56,7 @@ type Store struct {
 	ProfileDeploymentMetrics  *ProfileDeploymentMetricsStore
 	PostConfigAddons          *PostConfigAddonStore
 	PostConfigTemplates       *PostConfigTemplateStore
+	ClusterTemplates          *ClusterTemplateStore
 	Teams                     *TeamStore
 	TeamAdmins                *TeamAdminStore
 	TeamMemberships           *TeamMembershipStore
@@ -95,6 +96,7 @@ func New(pool *pgxpool.Pool) *Store {
 	s.ProfileDeploymentMetrics = &ProfileDeploymentMetricsStore{pool: pool}
 	s.PostConfigAddons = &PostConfigAddonStore{pool: pool}
 	s.PostConfigTemplates = &PostConfigTemplateStore{pool: pool}
+	s.ClusterTemplates = &ClusterTemplateStore{pool: pool}
 	s.Teams = &TeamStore{db: pool}
 	s.TeamAdmins = &TeamAdminStore{db: pool}
 	s.TeamMemberships = &TeamMembershipStore{db: pool}

--- a/pkg/types/cluster_template.go
+++ b/pkg/types/cluster_template.go
@@ -1,0 +1,18 @@
+package types
+
+import (
+	"encoding/json"
+	"time"
+)
+
+// ClusterTemplate stores reusable cluster-creation parameters for a single user.
+// Config is a partial create-cluster payload; when a template is applied only the
+// fields present in Config are pre-filled, and the cluster name is never stored.
+type ClusterTemplate struct {
+	ID        string          `db:"id" json:"id"`
+	Name      string          `db:"name" json:"name"`
+	OwnerID   string          `db:"owner_id" json:"ownerId"`
+	Config    json.RawMessage `db:"config" json:"config"`
+	CreatedAt time.Time       `db:"created_at" json:"createdAt"`
+	UpdatedAt time.Time       `db:"updated_at" json:"updatedAt"`
+}

--- a/web/app/(dashboard)/clusters/[id]/page.tsx
+++ b/web/app/(dashboard)/clusters/[id]/page.tsx
@@ -14,6 +14,7 @@ import { StorageTab } from "@/components/clusters/StorageTab";
 import { ClusterTopology } from "@/components/clusters/ClusterTopology";
 import { EC2InstancesCard } from "@/components/clusters/EC2InstancesCard";
 import { AddonExecutionOrder } from "@/components/clusters/AddonExecutionOrder";
+import { SaveClusterSettingsPrompt } from "@/components/clusters/SaveClusterSettingsPrompt";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
 import { formatDate, formatTTL, formatCurrency } from "@/lib/utils/formatters";
 import { ArrowLeft, Trash2, Clock, ExternalLink, Download, Copy, Moon, Sunrise, FileText, Eye, EyeOff, RotateCcw } from "lucide-react";
@@ -325,6 +326,7 @@ export default function ClusterDetailPage() {
 
   return (
     <div className="space-y-6">
+      <SaveClusterSettingsPrompt />
       <div className="flex items-center justify-between">
         <div className="flex items-center space-x-4">
           <Button variant="ghost" size="sm" onClick={() => router.back()}>

--- a/web/app/(dashboard)/clusters/new/page.tsx
+++ b/web/app/(dashboard)/clusters/new/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState, useMemo } from "react";
+import { useEffect, useState, useMemo, useRef } from "react";
 import { useRouter } from "next/navigation";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -18,6 +18,7 @@ import { Switch } from "@/components/ui/switch";
 import { Badge } from "@/components/ui/badge";
 import { TagsInput } from "@/components/ui/tags-input";
 import { CustomPostConfigEditor } from "@/components/postconfig/CustomPostConfigEditor";
+import { ClusterTemplateBar } from "@/components/clusters/ClusterTemplateBar";
 import {
   Select,
   SelectContent,
@@ -59,6 +60,7 @@ export default function NewClusterPage() {
     handleSubmit,
     watch,
     setValue,
+    getValues,
     formState: { errors },
   } = useForm<CreateClusterFormData>({
     resolver: zodResolver(createClusterSchema),
@@ -88,6 +90,45 @@ export default function NewClusterPage() {
   });
 
   const watchedValues = watch();
+
+  // Template fields that can be captured/restored (cluster name is intentionally excluded).
+  const TEMPLATE_FIELDS: (keyof CreateClusterFormData)[] = [
+    "platform", "cluster_type", "version", "profile", "region", "base_domain",
+    "owner", "team", "cost_center", "ttl_hours", "ssh_public_key", "extra_tags",
+    "offhours_opt_in", "skip_post_deployment", "postConfigAddOns", "customPostConfig",
+    "enable_efs_storage", "preserve_on_failure", "credentials_mode", "custom_pull_secret",
+    "override_work_hours", "work_hours_enabled", "work_hours_start", "work_hours_end", "work_days",
+  ];
+
+  // Holds a template awaiting re-application so it wins over profile-derived defaults.
+  const pendingTemplate = useRef<Record<string, unknown> | null>(null);
+
+  const applyTemplateToForm = (config: Record<string, unknown>) => {
+    for (const field of TEMPLATE_FIELDS) {
+      const value = config[field];
+      if (value !== undefined && value !== null) {
+        setValue(field, value as never, { shouldValidate: true });
+      }
+    }
+  };
+
+  const handleApplyTemplate = (config: Record<string, unknown>) => {
+    if (config.platform) setSelectedPlatform(config.platform as Platform);
+    if (config.cluster_type) setSelectedClusterType(config.cluster_type as ClusterType);
+    applyTemplateToForm(config);
+    // Re-apply once the profile-change effect has run so template values are not
+    // overwritten by profile defaults.
+    pendingTemplate.current = config;
+  };
+
+  const getCurrentConfig = (): Record<string, unknown> => {
+    const values = getValues();
+    const config: Record<string, unknown> = {};
+    for (const field of TEMPLATE_FIELDS) {
+      config[field] = values[field];
+    }
+    return config;
+  };
 
   // Filter profiles by platform, cluster type, and track, then sort alphabetically
   const sortedProfiles = useMemo(() => {
@@ -234,6 +275,13 @@ export default function NewClusterPage() {
           }));
           setValue("postConfigAddOns", defaultAddonSelections, { shouldValidate: true });
         }
+
+        // Re-apply a just-loaded template so its values take precedence over the
+        // profile defaults set above.
+        if (pendingTemplate.current) {
+          applyTemplateToForm(pendingTemplate.current);
+          pendingTemplate.current = null;
+        }
       }, 0);
     }
   }, [selectedProfile, setValue, watchedValues.cluster_type]);
@@ -278,6 +326,16 @@ export default function NewClusterPage() {
       }
 
       const result = await createCluster.mutateAsync(payload);
+      // Stash the settings used so the cluster detail page can offer to save them
+      // as a template when they don't already match one.
+      try {
+        sessionStorage.setItem(
+          "ocpctl:new-cluster-template-config",
+          JSON.stringify(getCurrentConfig())
+        );
+      } catch {
+        // sessionStorage may be unavailable; the prompt is a best-effort convenience.
+      }
       router.push(`/clusters/${result.id}`);
     } catch (error) {
       console.error("Failed to create cluster:", error);
@@ -303,6 +361,8 @@ export default function NewClusterPage() {
           Request a new Kubernetes cluster (OpenShift, EKS, or IKS)
         </p>
       </div>
+
+      <ClusterTemplateBar onApply={handleApplyTemplate} getCurrentConfig={getCurrentConfig} />
 
       <form onSubmit={handleSubmit(onSubmit)}>
         <div className="grid grid-cols-2 gap-8">

--- a/web/components/clusters/ClusterTemplateBar.tsx
+++ b/web/components/clusters/ClusterTemplateBar.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+import { useState } from "react";
+import {
+  useClusterTemplates,
+  useDeleteClusterTemplate,
+} from "@/lib/hooks/useClusterTemplates";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Download, Save, Trash2 } from "lucide-react";
+import type { ClusterTemplate } from "@/types/api";
+import {
+  SaveTemplateDialog,
+  MAX_CLUSTER_TEMPLATES,
+} from "@/components/clusters/SaveTemplateDialog";
+
+interface ClusterTemplateBarProps {
+  // Apply a template's stored fields to the create-cluster form.
+  onApply: (config: Record<string, unknown>) => void;
+  // Snapshot of the current form values to persist as a new template.
+  getCurrentConfig: () => Record<string, unknown>;
+}
+
+export function ClusterTemplateBar({ onApply, getCurrentConfig }: ClusterTemplateBarProps) {
+  const { data, isLoading } = useClusterTemplates();
+  const deleteMutation = useDeleteClusterTemplate();
+
+  const [selectedId, setSelectedId] = useState<string>("");
+  const [saveOpen, setSaveOpen] = useState(false);
+
+  const templates = data?.templates || [];
+  const selected = templates.find((t) => t.id === selectedId);
+
+  const handleApply = () => {
+    if (selected) {
+      onApply(selected.config);
+    }
+  };
+
+  const handleDelete = async () => {
+    if (!selected) return;
+    await deleteMutation.mutateAsync(selected.id);
+    setSelectedId("");
+  };
+
+  return (
+    <div className="rounded-lg border bg-muted/30 p-4">
+      <div className="flex items-end gap-3 flex-wrap">
+        <div className="flex-1 min-w-[220px] space-y-2">
+          <Label htmlFor="cluster-template-select">Load from template</Label>
+          <Select value={selectedId} onValueChange={setSelectedId} disabled={isLoading}>
+            <SelectTrigger id="cluster-template-select">
+              <SelectValue placeholder={isLoading ? "Loading..." : "Choose a template..."} />
+            </SelectTrigger>
+            <SelectContent>
+              {templates.length === 0 ? (
+                <div className="p-2 text-sm text-muted-foreground">No templates saved yet</div>
+              ) : (
+                templates.map((t: ClusterTemplate) => (
+                  <SelectItem key={t.id} value={t.id}>
+                    {t.name}
+                  </SelectItem>
+                ))
+              )}
+            </SelectContent>
+          </Select>
+        </div>
+
+        <Button type="button" onClick={handleApply} disabled={!selected}>
+          <Download className="h-4 w-4 mr-2" />
+          Apply
+        </Button>
+
+        <Button
+          type="button"
+          variant="outline"
+          onClick={handleDelete}
+          disabled={!selected || deleteMutation.isPending}
+          title="Delete selected template"
+        >
+          <Trash2 className="h-4 w-4" />
+        </Button>
+
+        <div className="ml-auto">
+          <Button type="button" variant="secondary" onClick={() => setSaveOpen(true)}>
+            <Save className="h-4 w-4 mr-2" />
+            Save as template
+          </Button>
+        </div>
+      </div>
+
+      <p className="mt-2 text-xs text-muted-foreground">
+        Applying a template pre-fills the fields it contains. The cluster name is never
+        included and any fields not in the template are left for you to complete. You can
+        save up to {MAX_CLUSTER_TEMPLATES} templates.
+      </p>
+
+      <SaveTemplateDialog
+        open={saveOpen}
+        onOpenChange={setSaveOpen}
+        getConfig={getCurrentConfig}
+      />
+    </div>
+  );
+}

--- a/web/components/clusters/SaveClusterSettingsPrompt.tsx
+++ b/web/components/clusters/SaveClusterSettingsPrompt.tsx
@@ -1,0 +1,107 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useClusterTemplates } from "@/lib/hooks/useClusterTemplates";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Save } from "lucide-react";
+import { SaveTemplateDialog } from "@/components/clusters/SaveTemplateDialog";
+
+const STORAGE_KEY = "ocpctl:new-cluster-template-config";
+
+// Canonical JSON with sorted keys and undefined values dropped, so two configs
+// that differ only in key order or absent fields compare equal.
+function canonical(value: unknown): string {
+  const sort = (v: unknown): unknown => {
+    if (Array.isArray(v)) return v.map(sort);
+    if (v && typeof v === "object") {
+      return Object.keys(v as Record<string, unknown>)
+        .sort()
+        .reduce<Record<string, unknown>>((acc, k) => {
+          acc[k] = sort((v as Record<string, unknown>)[k]);
+          return acc;
+        }, {});
+    }
+    return v;
+  };
+  return JSON.stringify(sort(JSON.parse(JSON.stringify(value ?? {}))));
+}
+
+// Reads the just-created cluster's settings from sessionStorage and, if they don't
+// already match one of the user's saved templates, offers to save them as a template.
+export function SaveClusterSettingsPrompt() {
+  const { data, isLoading } = useClusterTemplates();
+  const [pendingConfig, setPendingConfig] = useState<Record<string, unknown> | null>(null);
+  const [confirmOpen, setConfirmOpen] = useState(false);
+  const [saveOpen, setSaveOpen] = useState(false);
+
+  // Consume the stashed config once on mount.
+  useEffect(() => {
+    try {
+      const raw = sessionStorage.getItem(STORAGE_KEY);
+      if (raw) {
+        sessionStorage.removeItem(STORAGE_KEY);
+        setPendingConfig(JSON.parse(raw));
+      }
+    } catch {
+      // Ignore malformed/unavailable storage.
+    }
+  }, []);
+
+  // Once templates load, decide whether to prompt.
+  useEffect(() => {
+    if (!pendingConfig || isLoading) return;
+    const templates = data?.templates || [];
+    const target = canonical(pendingConfig);
+    const alreadySaved = templates.some((t) => canonical(t.config) === target);
+    if (!alreadySaved) {
+      setConfirmOpen(true);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [pendingConfig, isLoading]);
+
+  if (!pendingConfig) return null;
+
+  return (
+    <>
+      <Dialog open={confirmOpen} onOpenChange={setConfirmOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Save these settings as a template?</DialogTitle>
+            <DialogDescription>
+              You just created this cluster with settings you haven&apos;t saved. Save them
+              as a template to reuse them next time. The cluster name is not stored.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setConfirmOpen(false)}>
+              Not now
+            </Button>
+            <Button
+              onClick={() => {
+                setConfirmOpen(false);
+                setSaveOpen(true);
+              }}
+            >
+              <Save className="h-4 w-4 mr-2" />
+              Save as template
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <SaveTemplateDialog
+        open={saveOpen}
+        onOpenChange={setSaveOpen}
+        getConfig={() => pendingConfig}
+      />
+    </>
+  );
+}

--- a/web/components/clusters/SaveTemplateDialog.tsx
+++ b/web/components/clusters/SaveTemplateDialog.tsx
@@ -1,0 +1,222 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+  useClusterTemplates,
+  useCreateClusterTemplate,
+  useUpdateClusterTemplate,
+} from "@/lib/hooks/useClusterTemplates";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Save, Loader2 } from "lucide-react";
+import { ApiError } from "@/lib/api/client";
+
+// Mirrors MaxTemplatesPerUser in internal/store/cluster_templates.go.
+export const MAX_CLUSTER_TEMPLATES = 5;
+
+type Mode = "new" | "overwrite";
+
+interface SaveTemplateDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  // Snapshot of the form/config values to persist (cluster name excluded).
+  getConfig: () => Record<string, unknown>;
+  onSaved?: () => void;
+}
+
+export function SaveTemplateDialog({
+  open,
+  onOpenChange,
+  getConfig,
+  onSaved,
+}: SaveTemplateDialogProps) {
+  const { data } = useClusterTemplates();
+  const createMutation = useCreateClusterTemplate();
+  const updateMutation = useUpdateClusterTemplate();
+
+  const templates = data?.templates || [];
+  const atLimit = templates.length >= MAX_CLUSTER_TEMPLATES;
+
+  const [mode, setMode] = useState<Mode>("new");
+  const [name, setName] = useState("");
+  const [targetId, setTargetId] = useState("");
+  const [error, setError] = useState("");
+
+  // Reset the dialog each time it opens; force overwrite when the user is at the limit.
+  useEffect(() => {
+    if (open) {
+      setMode(atLimit && templates.length > 0 ? "overwrite" : "new");
+      setName("");
+      setTargetId("");
+      setError("");
+    }
+  }, [open, atLimit, templates.length]);
+
+  const pending = createMutation.isPending || updateMutation.isPending;
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError("");
+    const config = getConfig();
+
+    try {
+      if (mode === "overwrite") {
+        const target = templates.find((t) => t.id === targetId);
+        if (!target) {
+          setError("Select a template to overwrite.");
+          return;
+        }
+        await updateMutation.mutateAsync({
+          id: target.id,
+          data: { name: target.name, config },
+        });
+      } else {
+        const trimmed = name.trim();
+        if (trimmed.length < 3) {
+          setError("Name must be at least 3 characters.");
+          return;
+        }
+        await createMutation.mutateAsync({ name: trimmed, config });
+      }
+      onSaved?.();
+      onOpenChange(false);
+    } catch (err) {
+      if (err instanceof ApiError && err.response?.message) {
+        setError(err.response.message);
+      } else {
+        setError("Failed to save template. A template with this name may already exist.");
+      }
+    }
+  };
+
+  const canOverwrite = templates.length > 0;
+  const submitDisabled =
+    pending ||
+    (mode === "new" ? name.trim().length < 3 : !targetId);
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <form onSubmit={handleSubmit}>
+          <DialogHeader>
+            <DialogTitle>Save as template</DialogTitle>
+            <DialogDescription>
+              Save the current settings as a reusable template. The cluster name is not
+              stored.
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="space-y-4 py-4">
+            {canOverwrite && (
+              <div className="flex gap-2">
+                <Button
+                  type="button"
+                  size="sm"
+                  variant={mode === "new" ? "default" : "outline"}
+                  onClick={() => setMode("new")}
+                  disabled={atLimit}
+                  title={atLimit ? `You already have ${MAX_CLUSTER_TEMPLATES} templates` : undefined}
+                >
+                  New template
+                </Button>
+                <Button
+                  type="button"
+                  size="sm"
+                  variant={mode === "overwrite" ? "default" : "outline"}
+                  onClick={() => setMode("overwrite")}
+                >
+                  Overwrite existing
+                </Button>
+              </div>
+            )}
+
+            {atLimit && mode === "overwrite" && (
+              <p className="text-xs text-muted-foreground">
+                You have reached the limit of {MAX_CLUSTER_TEMPLATES} templates. Overwrite
+                one or delete a template to save a new one.
+              </p>
+            )}
+
+            {mode === "new" ? (
+              <div className="space-y-2">
+                <Label htmlFor="save-template-name">
+                  Name <span className="text-red-500">*</span>
+                </Label>
+                <Input
+                  id="save-template-name"
+                  placeholder="My standard AWS SNO"
+                  value={name}
+                  onChange={(e) => setName(e.target.value)}
+                  minLength={3}
+                  maxLength={100}
+                  autoFocus
+                  disabled={pending}
+                />
+              </div>
+            ) : (
+              <div className="space-y-2">
+                <Label htmlFor="save-template-target">
+                  Template to overwrite <span className="text-red-500">*</span>
+                </Label>
+                <Select value={targetId} onValueChange={setTargetId} disabled={pending}>
+                  <SelectTrigger id="save-template-target">
+                    <SelectValue placeholder="Choose a template..." />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {templates.map((t) => (
+                      <SelectItem key={t.id} value={t.id}>
+                        {t.name}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+            )}
+
+            {error && <p className="text-sm text-red-600 dark:text-red-400">{error}</p>}
+          </div>
+
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => onOpenChange(false)}
+              disabled={pending}
+            >
+              Cancel
+            </Button>
+            <Button type="submit" disabled={submitDisabled}>
+              {pending ? (
+                <>
+                  <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                  Saving...
+                </>
+              ) : (
+                <>
+                  <Save className="h-4 w-4 mr-2" />
+                  Save
+                </>
+              )}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/web/lib/api/endpoints/clusterTemplates.ts
+++ b/web/lib/api/endpoints/clusterTemplates.ts
@@ -1,0 +1,33 @@
+import { apiClient } from "../client";
+import type {
+  ClusterTemplate,
+  ClusterTemplatesResponse,
+} from "@/types/api";
+
+export const clusterTemplatesApi = {
+  list: async (): Promise<ClusterTemplatesResponse> => {
+    return apiClient.get<ClusterTemplatesResponse>(`/cluster-templates`);
+  },
+
+  get: async (id: string): Promise<ClusterTemplate> => {
+    return apiClient.get<ClusterTemplate>(`/cluster-templates/${id}`);
+  },
+
+  create: async (data: {
+    name: string;
+    config: Record<string, unknown>;
+  }): Promise<ClusterTemplate> => {
+    return apiClient.post<ClusterTemplate>(`/cluster-templates`, data);
+  },
+
+  update: async (
+    id: string,
+    data: { name: string; config: Record<string, unknown> }
+  ): Promise<ClusterTemplate> => {
+    return apiClient.patch<ClusterTemplate>(`/cluster-templates/${id}`, data);
+  },
+
+  delete: async (id: string): Promise<void> => {
+    return apiClient.delete<void>(`/cluster-templates/${id}`);
+  },
+};

--- a/web/lib/api/index.ts
+++ b/web/lib/api/index.ts
@@ -6,5 +6,6 @@ export { jobsApi } from "./endpoints/jobs";
 export { usersApi } from "./users";
 export { orphanedResourcesApi } from "./endpoints/orphaned-resources";
 export { postConfigApi } from "./endpoints/postconfig";
+export { clusterTemplatesApi } from "./endpoints/clusterTemplates";
 export { poolsApi } from "./endpoints/pools";
 export { adminApi } from "./endpoints/admin";

--- a/web/lib/hooks/useClusterTemplates.ts
+++ b/web/lib/hooks/useClusterTemplates.ts
@@ -1,0 +1,50 @@
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { clusterTemplatesApi } from "../api";
+
+export function useClusterTemplates() {
+  return useQuery({
+    queryKey: ["clusterTemplates"],
+    queryFn: () => clusterTemplatesApi.list(),
+    staleTime: 60 * 1000,
+  });
+}
+
+export function useCreateClusterTemplate() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (data: { name: string; config: Record<string, unknown> }) =>
+      clusterTemplatesApi.create(data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["clusterTemplates"] });
+    },
+  });
+}
+
+export function useUpdateClusterTemplate() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({
+      id,
+      data,
+    }: {
+      id: string;
+      data: { name: string; config: Record<string, unknown> };
+    }) => clusterTemplatesApi.update(id, data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["clusterTemplates"] });
+    },
+  });
+}
+
+export function useDeleteClusterTemplate() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (id: string) => clusterTemplatesApi.delete(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["clusterTemplates"] });
+    },
+  });
+}

--- a/web/types/api.ts
+++ b/web/types/api.ts
@@ -665,6 +665,21 @@ export interface PostConfigTemplatesResponse {
   templates: PostConfigTemplate[];
 }
 
+// Cluster-creation Template Types
+// config is a partial create-cluster form payload; only present fields are pre-filled.
+export interface ClusterTemplate {
+  id: string;
+  name: string;
+  ownerId: string;
+  config: Record<string, unknown>;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface ClusterTemplatesResponse {
+  templates: ClusterTemplate[];
+}
+
 // Post-Config Validation Types
 export interface DAGInfo {
   executionOrder: string[];


### PR DESCRIPTION
This allows the users to save their common configurations as form templates so they could recreate clusters with exact same settings using those templates. 