### PR TITLE
Fix autoscaled worker profile path + Azure CLI install on Amazon Linux (#80)

### DIFF
--- a/scripts/ensure-installers.sh
+++ b/scripts/ensure-installers.sh
@@ -380,14 +380,41 @@ ensure_azure_cli() {
 
     log "Installing Azure CLI..."
 
-    # Install Azure CLI using Microsoft's official script
-    if curl -sL https://aka.ms/InstallAzureCLIDeb | bash > /dev/null 2>&1; then
-        log "✓ Installed Azure CLI"
-        return 0
-    else
-        log "ERROR: Failed to install Azure CLI"
+    # Debian/Ubuntu (the primary hybrid host): Microsoft's apt install script.
+    if command -v apt-get &> /dev/null; then
+        if curl -sL https://aka.ms/InstallAzureCLIDeb | bash > /dev/null 2>&1; then
+            log "✓ Installed Azure CLI (deb)"
+            return 0
+        fi
+        log "ERROR: Failed to install Azure CLI (deb)"
         return 1
     fi
+
+    # RHEL / Amazon Linux (autoscaled workers): the Deb script does not work here,
+    # so use Microsoft's yum/dnf repo. Without this az is absent and azure-login.sh
+    # silently skips, so ARO jobs cannot run on autoscaled workers (#80).
+    if command -v dnf &> /dev/null || command -v yum &> /dev/null; then
+        local pkgmgr
+        pkgmgr=$(command -v dnf || command -v yum)
+        rpm --import https://packages.microsoft.com/keys/microsoft.asc > /dev/null 2>&1
+        cat > /etc/yum.repos.d/azure-cli.repo <<'AZREPO'
+[azure-cli]
+name=Azure CLI
+baseurl=https://packages.microsoft.com/yumrepos/azure-cli
+enabled=1
+gpgcheck=1
+gpgkey=https://packages.microsoft.com/keys/microsoft.asc
+AZREPO
+        if "$pkgmgr" install -y azure-cli > /dev/null 2>&1; then
+            log "✓ Installed Azure CLI (rpm)"
+            return 0
+        fi
+        log "ERROR: Failed to install Azure CLI (rpm)"
+        return 1
+    fi
+
+    log "ERROR: Failed to install Azure CLI (no supported package manager)"
+    return 1
 }
 
 ensure_gcloud() {

--- a/terraform/worker-autoscaling/main.tf
+++ b/terraform/worker-autoscaling/main.tf
@@ -59,11 +59,12 @@ resource "aws_launch_template" "worker" {
   # - OpenShift installer binaries for multiple versions (~3GB)
   # - Cluster work directories (~5GB per concurrent cluster)
   # - Journal logs and temp files (~2GB)
-  # Minimum: 30GB for workers running up to 3 concurrent clusters
+  # Raised to 80GB in production for more binary storage (was 30GB); adopted here so
+  # terraform does not revert the volume size on the next apply.
   block_device_mappings {
     device_name = "/dev/xvda"
     ebs {
-      volume_size           = 30
+      volume_size           = 80
       volume_type           = "gp3"
       delete_on_termination = true
       encrypted             = true

--- a/terraform/worker-autoscaling/user-data.sh
+++ b/terraform/worker-autoscaling/user-data.sh
@@ -59,10 +59,12 @@ aws s3 cp "$WORKER_BINARY_URL" /usr/local/bin/ocpctl-worker
 chmod +x /usr/local/bin/ocpctl-worker
 chown root:root /usr/local/bin/ocpctl-worker
 
-# Download profile definitions
+# Download profile definitions. Must land directly in /opt/ocpctl/profiles to match
+# PROFILES_DIR in the shared worker.env (the primary-host layout); a nested
+# definitions/ subdir leaves the worker finding zero profiles and exiting (#80).
 echo "Downloading profile definitions"
-mkdir -p /opt/ocpctl/profiles/definitions
-aws s3 sync s3://ocpctl-binaries/profiles/ /opt/ocpctl/profiles/definitions/
+mkdir -p /opt/ocpctl/profiles
+aws s3 sync s3://ocpctl-binaries/profiles/ /opt/ocpctl/profiles/
 chown -R ocpctl:ocpctl /opt/ocpctl/profiles
 
 # Download CLI login hooks + installer script referenced by the worker service.


### PR DESCRIPTION
## Summary

Follow-on to #82. Validating the #80 fix on a real autoscaled worker (Amazon Linux 2023) surfaced two issues that kept a fresh ASG worker from coming up correctly:

1. **Profile path regression (crash-loop):** the shared `worker.env` (now pulled from S3) sets `PROFILES_DIR=/opt/ocpctl/profiles`, but the terraform user-data still synced profiles into `/opt/ocpctl/profiles/definitions/`. The worker found zero profiles and exited 1, crash-looping. Now syncs directly into `/opt/ocpctl/profiles/` to match the shared env.
2. **Azure CLI never installed on ASG workers:** `ensure_azure_cli` only used Microsoft's Debian install script (works on the Ubuntu primary host, fails on AL2023). With `az` absent, `azure-login.sh` silently skipped and ARO jobs could not run. Added a RHEL/Amazon-Linux dnf-repo path.

Also adopts the out-of-band production launch-template change that raised the worker root volume 30GB → 80GB so `terraform apply` does not revert it.

## Validation

Both fixes validated live end-to-end on autoscaled worker `i-04275f6dbc2ad2e63`:
- worker `active` with 37 profiles loaded
- `az login` succeeds; `az account show` → `migration-eng` subscription, session persisted to `/opt/ocpctl/.azure`
- `/ready` returns ready

`bash -n` passes on both scripts; `terraform validate` → Success.

Relates to #80

🤖 Generated with [Claude Code](https://claude.com/claude-code)