### PR TITLE
Harden deploy DB-URL read and ARO client-secret argv (#80, #81)

### DIFF
--- a/internal/installer/aro.go
+++ b/internal/installer/aro.go
@@ -219,7 +219,23 @@ func (a *AROInstaller) CreateCluster(ctx context.Context, config *AROClusterConf
 	// stops az aro create from creating a new app registration in Entra ID, which
 	// requires Microsoft Graph write permissions the worker SP lacks.
 	if config.ClientID != "" && config.ClientSecret != "" {
-		args = append(args, "--client-id", config.ClientID, "--client-secret", config.ClientSecret)
+		// Pass the client secret via Azure CLI's @<file> convention instead of as a
+		// literal argument, so the secret never appears in the process argument list
+		// (readable by any local user via `ps`) (#81). os.CreateTemp makes the file
+		// 0600; it is removed when this function returns.
+		secretFile, err := os.CreateTemp("", "aro-client-secret-*")
+		if err != nil {
+			return "", fmt.Errorf("create client-secret temp file: %w", err)
+		}
+		defer os.Remove(secretFile.Name())
+		if _, err := secretFile.WriteString(config.ClientSecret); err != nil {
+			secretFile.Close()
+			return "", fmt.Errorf("write client-secret temp file: %w", err)
+		}
+		if err := secretFile.Close(); err != nil {
+			return "", fmt.Errorf("close client-secret temp file: %w", err)
+		}
+		args = append(args, "--client-id", config.ClientID, "--client-secret", "@"+secretFile.Name())
 	}
 
 	// Add pull secret

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -279,7 +279,7 @@ for host in "${WORKER_HOSTS[@]}"; do
     # Requeue any RUNNING jobs before stopping worker (prevents orphaned jobs)
     echo -e "${YELLOW}  Requeuing any in-progress jobs...${NC}"
     # Extract DATABASE_URL from worker.env and use it for RDS connection
-    REQUEUED=$(ssh -i "$SSH_KEY" $SSH_USER@$host 'DATABASE_URL=$(grep "^DATABASE_URL=" /etc/ocpctl/worker.env | cut -d= -f2-); psql "$DATABASE_URL" -t -c "UPDATE jobs SET status = '"'"'PENDING'"'"', started_at = NULL WHERE status = '"'"'RUNNING'"'"' RETURNING id;" 2>/dev/null | grep -o "-" | wc -l | tr -d " "' || echo "0")
+    REQUEUED=$(ssh -i "$SSH_KEY" $SSH_USER@$host 'DATABASE_URL=$(sudo grep "^DATABASE_URL=" /etc/ocpctl/worker.env | cut -d= -f2- | tr -d "\""); psql "$DATABASE_URL" -t -c "UPDATE jobs SET status = '"'"'PENDING'"'"', started_at = NULL WHERE status = '"'"'RUNNING'"'"' RETURNING id;" 2>/dev/null | grep -o "-" | wc -l | tr -d " "' || echo "0")
     if [ "$REQUEUED" -gt 0 ] 2>/dev/null; then
         echo -e "${GREEN}✓ Requeued $REQUEUED job(s) to PENDING status${NC}"
     else
@@ -289,7 +289,7 @@ for host in "${WORKER_HOSTS[@]}"; do
     # Clear any stale job locks from this worker (prevents blocked jobs after restart)
     echo -e "${YELLOW}  Clearing stale job locks...${NC}"
     INSTANCE_ID=$(ssh -i "$SSH_KEY" $SSH_USER@$host 'ec2-metadata --instance-id 2>/dev/null | cut -d " " -f 2' || echo "unknown")
-    LOCKS_CLEARED=$(ssh -i "$SSH_KEY" $SSH_USER@$host 'DATABASE_URL=$(grep "^DATABASE_URL=" /etc/ocpctl/worker.env | cut -d= -f2-); psql "$DATABASE_URL" -t -c "DELETE FROM job_locks WHERE locked_by LIKE '"'"'%'$INSTANCE_ID'%'"'"' RETURNING job_id;" 2>/dev/null | grep -o "-" | wc -l | tr -d " "' || echo "0")
+    LOCKS_CLEARED=$(ssh -i "$SSH_KEY" $SSH_USER@$host 'DATABASE_URL=$(sudo grep "^DATABASE_URL=" /etc/ocpctl/worker.env | cut -d= -f2- | tr -d "\""); psql "$DATABASE_URL" -t -c "DELETE FROM job_locks WHERE locked_by LIKE '"'"'%'$INSTANCE_ID'%'"'"' RETURNING job_id;" 2>/dev/null | grep -o "-" | wc -l | tr -d " "' || echo "0")
     if [ "$LOCKS_CLEARED" -gt 0 ] 2>/dev/null; then
         echo -e "${GREEN}✓ Cleared $LOCKS_CLEARED stale lock(s)${NC}"
     else


### PR DESCRIPTION
## Summary

- **`deploy.sh` (#80):** the requeue/lock-clear steps grepped `DATABASE_URL` from `/etc/ocpctl/worker.env` as the SSH user, but that file is now `chmod 600` owned by `ocpctl`, so the grep failed with `Permission denied` and the steps silently no-oped (RUNNING jobs would not be requeued on deploy). Now reads it via `sudo` and strips surrounding quotes.
- **`aro.go` (#81):** `az aro create` received `--client-secret` as a literal argument, so the cluster service-principal secret was visible in the process argument list via `ps`. Now passed via Azure CLI's `@<file>` convention (0600 temp file, removed on return) — the same `@file` pattern the official ARO docs use for `--pull-secret`.

## Validation

- `bash -n scripts/deploy.sh` passes
- `go build`, `go vet`, and `go test ./internal/installer/` all pass

Note: the `@file` path for `--client-secret` will be exercised end-to-end by the first real ARO create after deploy.

Relates to #80, #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)