### PR TITLE
Update aro-standard profile to OpenShift 4.18-4.21

### DIFF
--- a/internal/profile/definitions/aro-standard.yaml
+++ b/internal/profile/definitions/aro-standard.yaml
@@ -7,12 +7,11 @@ track: ga
 enabled: true
 openshiftVersions:
   allowlist:
-  - '4.16'
-  - '4.17'
   - '4.18'
   - '4.19'
   - '4.20'
-  default: '4.20'
+  - '4.21'
+  default: '4.21'
 regions:
   allowlist:
   - eastus


### PR DESCRIPTION
## Summary

`aro-standard.yaml` advertised OpenShift `4.16`–`4.20`, but `az aro get-versions` currently returns only **4.18, 4.19, 4.20, 4.21** — consistently across all seven allowlisted regions (eastus, eastus2, westus, westus2, centralus, northeurope, westeurope).

The profile was stale in both directions:
- **Missing 4.21** — newest GA, available in every region.
- **Listed 4.16 / 4.17** — aged out of ARO; a create pinned to those would fail in `ResolveVersion` with *"no ARO-supported patch version found"*.

## Change

- allowlist: `4.16, 4.17, 4.18, 4.19, 4.20` → `4.18, 4.19, 4.20, 4.21`
- default: `4.20` → `4.21`

Profile-only YAML change. `go test ./internal/profile/...` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)