### PR TITLE
Prune stale profiles from DB on startup sync

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -185,6 +185,20 @@ func main() {
 	}
 	log.Printf("✓ Synced %d profiles to database", syncedCount)
 
+	// Prune profiles whose YAML source was renamed or removed. The upsert loop
+	// above only ever adds/updates, so without this a renamed profile leaves its
+	// old row behind and the UI shows a duplicate card (the pre-rename
+	// azure-aro-standard lingered in the DB alongside aro-standard).
+	keepProfiles := make([]string, 0, len(allProfiles))
+	for _, prof := range allProfiles {
+		keepProfiles = append(keepProfiles, prof.Name)
+	}
+	if pruned, err := st.DeleteProfilesNotIn(ctx, keepProfiles); err != nil {
+		log.Printf("Warning: Failed to prune stale profiles: %v", err)
+	} else if pruned > 0 {
+		log.Printf("✓ Pruned %d stale profile(s) from database", pruned)
+	}
+
 	// Sync add-ons from YAML to database
 	log.Println("Syncing add-ons from YAML...")
 	addonsDir := os.Getenv("ADDONS_DIR")

--- a/internal/store/profiles.go
+++ b/internal/store/profiles.go
@@ -165,6 +165,27 @@ func (s *Store) DeleteProfile(ctx context.Context, name string) error {
 	return nil
 }
 
+// DeleteProfilesNotIn removes every profile whose name is not in keep, returning
+// the number deleted. The startup sync calls this after upserting the current
+// YAML profiles so that a profile whose source file was renamed or removed does
+// not linger as a stale row. Without it, renaming azure-aro-standard.yaml to
+// aro-standard.yaml left both rows in the table and the UI rendered two identical
+// ARO cards.
+func (s *Store) DeleteProfilesNotIn(ctx context.Context, keep []string) (int, error) {
+	// Guard against wiping the whole table if the caller passes an empty set
+	// (e.g. profiles failed to load) — pruning to zero is never intended.
+	if len(keep) == 0 {
+		return 0, nil
+	}
+
+	result, err := s.pool.Exec(ctx, `DELETE FROM profiles WHERE name != ALL($1)`, keep)
+	if err != nil {
+		return 0, fmt.Errorf("failed to prune profiles: %w", err)
+	}
+
+	return int(result.RowsAffected()), nil
+}
+
 // UpdateProfileVersions updates the version allowlist and default for a profile
 func (s *Store) UpdateProfileVersions(ctx context.Context, name string, addVersions []string, removeVersions []string, newDefault *string) error {
 	// Get current profile

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -159,11 +159,13 @@ ssh -i "$SSH_KEY" $SSH_USER@$API_HOST "sudo mkdir -p ${REMOTE_BASE}/releases/${V
 scp -i "$SSH_KEY" bin/ocpctl-api-${VERSION} $SSH_USER@$API_HOST:/tmp/ocpctl-api-${VERSION}
 ssh -i "$SSH_KEY" $SSH_USER@$API_HOST "sudo install -m 755 /tmp/ocpctl-api-${VERSION} ${REMOTE_BASE}/releases/${VERSION}/ocpctl-api && rm /tmp/ocpctl-api-${VERSION}"
 
-# Deploy profiles directory
+# Deploy profiles directory. Clear the destination first so a profile whose YAML
+# was renamed or removed does not linger on the host and get reloaded into the DB
+# as a stale duplicate (cp alone never deletes; see the azure-aro-standard dupe).
 echo -e "${YELLOW}  Deploying profiles directory...${NC}"
 ssh -i "$SSH_KEY" $SSH_USER@$API_HOST "mkdir -p /tmp/profiles && sudo mkdir -p ${REMOTE_BASE}/profiles"
 scp -i "$SSH_KEY" -r internal/profile/definitions/* $SSH_USER@$API_HOST:/tmp/profiles/
-ssh -i "$SSH_KEY" $SSH_USER@$API_HOST "sudo cp -r /tmp/profiles/* ${REMOTE_BASE}/profiles/ && sudo chown -R ocpctl:ocpctl ${REMOTE_BASE}/profiles && rm -rf /tmp/profiles"
+ssh -i "$SSH_KEY" $SSH_USER@$API_HOST "sudo rm -f ${REMOTE_BASE}/profiles/*.yaml ${REMOTE_BASE}/profiles/*.yml && sudo cp -r /tmp/profiles/* ${REMOTE_BASE}/profiles/ && sudo chown -R ocpctl:ocpctl ${REMOTE_BASE}/profiles && rm -rf /tmp/profiles"
 
 # Deploy add-ons directory
 echo -e "${YELLOW}  Deploying add-ons directory...${NC}"
@@ -252,11 +254,13 @@ for host in "${WORKER_HOSTS[@]}"; do
     scp -i "$SSH_KEY" scripts/configure-shared-migration-storage.sh $SSH_USER@$host:/tmp/worker-scripts/ 2>/dev/null || true
     ssh -i "$SSH_KEY" $SSH_USER@$host "sudo cp /tmp/worker-scripts/* ${REMOTE_BASE}/releases/${VERSION}/scripts/ 2>/dev/null || true && sudo chmod +x ${REMOTE_BASE}/releases/${VERSION}/scripts/*.sh 2>/dev/null || true && rm -rf /tmp/worker-scripts"
 
-    # Deploy profiles directory
+    # Deploy profiles directory. Clear the destination first so a renamed/removed
+    # profile does not linger on the host and get reloaded into the DB as a stale
+    # duplicate (cp alone never deletes; see the azure-aro-standard dupe).
     echo -e "${YELLOW}  Deploying profiles directory...${NC}"
     ssh -i "$SSH_KEY" $SSH_USER@$host "mkdir -p /tmp/profiles && sudo mkdir -p ${REMOTE_BASE}/profiles"
     scp -i "$SSH_KEY" -r internal/profile/definitions/* $SSH_USER@$host:/tmp/profiles/
-    ssh -i "$SSH_KEY" $SSH_USER@$host "sudo cp -r /tmp/profiles/* ${REMOTE_BASE}/profiles/ && sudo chown -R ocpctl:ocpctl ${REMOTE_BASE}/profiles && rm -rf /tmp/profiles"
+    ssh -i "$SSH_KEY" $SSH_USER@$host "sudo rm -f ${REMOTE_BASE}/profiles/*.yaml ${REMOTE_BASE}/profiles/*.yml && sudo cp -r /tmp/profiles/* ${REMOTE_BASE}/profiles/ && sudo chown -R ocpctl:ocpctl ${REMOTE_BASE}/profiles && rm -rf /tmp/profiles"
 
     # Deploy worker.env configuration
     if [ -f config/worker.env ]; then


### PR DESCRIPTION
## Problem

The UI rendered **two identical Azure Red Hat OpenShift Standard cards** (and the same duplication exists for AKS). Tracing it:

- The profiles endpoint serves from the `profiles` **database table**, populated by the API startup sync.
- That sync only ever **upserts** the current YAML profiles — it never deletes rows whose source file was renamed or removed.
- Commit `d1b8c1e` renamed `azure-aro-standard.yaml` → `aro-standard.yaml` (and `azure-aks-standard.yaml` → `aks-standard.yaml`). The new rows were added; the **old rows were never removed**, so `azure-aro-standard` / `azure-aks-standard` lingered as stale duplicates.

Prod host files and S3 were clean — the duplicate lived only in the DB, which is why no file/S3 check surfaced it.

Verified safe to delete: no FK references the `profiles` table, `clusters.profile` is a plain `VARCHAR`, and zero clusters reference the stale names.

## Fix

- **`internal/store/profiles.go`** — new `DeleteProfilesNotIn(keep)` that prunes rows not in the current set, with an empty-set guard so it can never wipe the table if profiles fail to load.
- **`cmd/api/main.go`** — call the prune right after the upsert loop; logs `✓ Pruned N stale profile(s) from database`. Mirrors the existing add-on syncer, which already prunes.
- **`scripts/deploy.sh`** — clear the host profiles dir (`rm -f *.yaml *.yml`) before `cp`. `cp` never deletes, so a renamed/removed file would otherwise linger on the host and get reloaded into the DB, re-creating the duplicate.

Self-healing: on the next API restart the prune removes both stale rows automatically — no manual DB edit. Builds + `go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)