### PR TITLE
Make ROSA admin creation idempotent across CREATE retries (#87)

### DIFF
--- a/internal/installer/installer_test.go
+++ b/internal/installer/installer_test.go
@@ -218,3 +218,75 @@ func TestNewInstallerForVersionDevPreviewParsing(t *testing.T) {
 		})
 	}
 }
+
+func TestIsAdminAlreadyExists(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want bool
+	}{
+		{
+			name: "rosa create admin exact error (#87)",
+			in:   "ERR: Cluster 'octl-mman-rosa-minimal-test' already has 'cluster-admin' user",
+			want: true,
+		},
+		{
+			name: "wrapped go error string",
+			in:   "rosa create admin failed: exit status 1\nStderr: ERR: Cluster 'x' already has 'cluster-admin' user",
+			want: true,
+		},
+		{
+			name: "admin variant wording",
+			in:   "Cluster 'x' already has 'admin' user",
+			want: true,
+		},
+		{
+			name: "unrelated failure",
+			in:   "rosa create admin failed: cluster is not ready",
+			want: false,
+		},
+		{
+			name: "empty",
+			in:   "",
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isAdminAlreadyExists(tt.in); got != tt.want {
+				t.Errorf("isAdminAlreadyExists(%q) = %v, want %v", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsAdminNotFound(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want bool
+	}{
+		{
+			name: "no admin present",
+			in:   "ERR: Cluster 'x' has no admin user",
+			want: true,
+		},
+		{
+			name: "not found wording",
+			in:   "admin user not found",
+			want: true,
+		},
+		{
+			name: "unrelated failure is not treated as absent",
+			in:   "rosa delete admin failed: connection refused",
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isAdminNotFound(tt.in); got != tt.want {
+				t.Errorf("isAdminNotFound(%q) = %v, want %v", tt.in, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/installer/rosa.go
+++ b/internal/installer/rosa.go
@@ -571,17 +571,14 @@ func (r *ROSAInstaller) GetKubeconfig(ctx context.Context, clusterName, outputPa
 		}
 	}
 
-	// Create admin user and get login command
-	// rosa create admin --cluster <name>
-	cmd := exec.CommandContext(ctx, r.binaryPath, "create", "admin",
-		"--cluster", clusterName)
-
-	var stdout, stderr bytes.Buffer
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
-
-	if err := cmd.Run(); err != nil {
-		return nil, fmt.Errorf("rosa create admin failed: %w\nStderr: %s", err, stderr.String())
+	// Create (or recover) the cluster-admin user and get the login command.
+	// rosa create admin is NOT idempotent: on a CREATE retry where the admin was
+	// created by an earlier attempt it fails with "already has 'cluster-admin'
+	// user", which used to fail the whole job even though the cluster is healthy
+	// (issue #87). ensureAdmin recovers by delete+recreate so retries succeed.
+	output, err := r.ensureAdmin(ctx, clusterName)
+	if err != nil {
+		return nil, err
 	}
 
 	// Output contains multiple INFO lines, need to extract just the "oc login" command
@@ -592,7 +589,6 @@ func (r *ROSAInstaller) GetKubeconfig(ctx context.Context, clusterName, outputPa
 	//      oc login https://api.xxx --username cluster-admin --password xxx
 	//
 	//   INFO: It may take several minutes...
-	output := stdout.String()
 
 	// Find the line containing "oc login"
 	var loginCmd string
@@ -655,6 +651,97 @@ func (r *ROSAInstaller) GetKubeconfig(ctx context.Context, clusterName, outputPa
 		Username: username,
 		Password: password,
 	}, nil
+}
+
+// ensureAdmin creates the cluster-admin user and returns the `rosa create admin`
+// stdout (which embeds the `oc login` command with credentials). Because
+// `rosa create admin` is not idempotent and rosa never re-displays an existing
+// admin's password, an admin left over from a prior CREATE attempt is recovered
+// by deleting and recreating it so the retry yields fresh, usable credentials
+// rather than failing the job (issue #87). This runs at create time, so no
+// external consumer depends on the discarded password.
+func (r *ROSAInstaller) ensureAdmin(ctx context.Context, clusterName string) (string, error) {
+	out, err := r.createAdmin(ctx, clusterName)
+	if err == nil {
+		return out, nil
+	}
+	if !isAdminAlreadyExists(err.Error()) {
+		return "", err
+	}
+
+	// Admin exists from an earlier attempt — delete it, then recreate. IDP
+	// changes propagate asynchronously, so retry the recreate briefly while rosa
+	// still reports the admin as present.
+	if derr := r.deleteAdmin(ctx, clusterName); derr != nil {
+		return "", fmt.Errorf("recover existing cluster-admin: %w", derr)
+	}
+
+	const (
+		recreateAttempts = 6
+		recreateDelay    = 10 * time.Second
+	)
+	var lastErr error
+	for attempt := 1; attempt <= recreateAttempts; attempt++ {
+		select {
+		case <-ctx.Done():
+			return "", ctx.Err()
+		case <-time.After(recreateDelay):
+		}
+		out, err = r.createAdmin(ctx, clusterName)
+		if err == nil {
+			return out, nil
+		}
+		lastErr = err
+		if !isAdminAlreadyExists(err.Error()) {
+			return "", err
+		}
+	}
+	return "", fmt.Errorf("recreate cluster-admin after delete (still reports existing after %d attempts): %w", recreateAttempts, lastErr)
+}
+
+// createAdmin runs `rosa create admin` and returns its stdout, which carries the
+// `oc login` command and the generated credentials.
+func (r *ROSAInstaller) createAdmin(ctx context.Context, clusterName string) (string, error) {
+	cmd := exec.CommandContext(ctx, r.binaryPath, "create", "admin", "--cluster", clusterName)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("rosa create admin failed: %w\nStderr: %s", err, stderr.String())
+	}
+	return stdout.String(), nil
+}
+
+// deleteAdmin removes the cluster-admin user so it can be recreated. A missing
+// admin is treated as success so the recovery path stays idempotent.
+func (r *ROSAInstaller) deleteAdmin(ctx context.Context, clusterName string) error {
+	cmd := exec.CommandContext(ctx, r.binaryPath, "delete", "admin", "--cluster", clusterName, "--yes")
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		if isAdminNotFound(stderr.String()) {
+			return nil
+		}
+		return fmt.Errorf("rosa delete admin failed: %w\nStderr: %s", err, stderr.String())
+	}
+	return nil
+}
+
+// isAdminAlreadyExists reports whether rosa output indicates the cluster-admin
+// user already exists (e.g. "Cluster 'x' already has 'cluster-admin' user").
+func isAdminAlreadyExists(s string) bool {
+	l := strings.ToLower(s)
+	return strings.Contains(l, "already has 'cluster-admin'") ||
+		strings.Contains(l, "already has 'admin'") ||
+		(strings.Contains(l, "cluster-admin") && strings.Contains(l, "already"))
+}
+
+// isAdminNotFound reports whether rosa output indicates there is no admin user to
+// delete, so deleteAdmin can treat that as success.
+func isAdminNotFound(s string) bool {
+	l := strings.ToLower(s)
+	return (strings.Contains(l, "no") && strings.Contains(l, "admin")) ||
+		strings.Contains(l, "not found")
 }
 
 // ListMachinePools lists all machine pools for a ROSA cluster


### PR DESCRIPTION
## Problem

ROSA install completes successfully, but the ocpctl CREATE job ends `FAILED`. `rosa create admin` is not idempotent — on a CREATE retry where the admin already exists (from an earlier attempt), or after a partial failure once admin was created, it errors:

```
ERR: Cluster '<name>' already has 'cluster-admin' user
```

CREATE jobs retry up to 3×, so this becomes `MAX_RETRIES_EXCEEDED` even though the cluster is healthy and ready (#87).

## Fix

`GetKubeconfig` now calls a new `ensureAdmin` helper (`internal/installer/rosa.go`):

- Try `rosa create admin` — unchanged happy path.
- On the **"already exists"** condition, **delete + recreate** the admin. `rosa` never re-displays an existing admin's password, so regenerating is the only way to obtain usable credentials. Runs at create time, so nothing external depends on the discarded password.
- Recreate retries with backoff (6×10s) to ride out ROSA's asynchronous IDP propagation between delete and recreate.
- `deleteAdmin` treats a missing admin as success (idempotent).

Covers both scenarios in the issue: pure retry (admin from attempt 1) and the login-only-failure chain (attempt 1 creates admin → `oc login` not ready → attempt 2 recovers).

## Scope

Genuine credential failures stay fatal (preserves #75 behavior); **only** the admin-already-exists case is recovered.

## Testing

- `TestIsAdminAlreadyExists` / `TestIsAdminNotFound` — table tests using the exact rosa error strings from the issue (incl. wrapped-error form).
- Full `internal/installer` suite passes; `go build ./...` and `go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)