### PR TITLE
Fix DATABASE_URL extraction in deploy-env.sh requeue/lock-clear steps

### DIFF
--- a/scripts/deploy-env.sh
+++ b/scripts/deploy-env.sh
@@ -317,7 +317,7 @@ for host in "${WORKER_HOSTS[@]}"; do
     # Requeue any RUNNING jobs before stopping worker (prevents orphaned jobs)
     echo -e "${YELLOW}  Requeuing any in-progress jobs...${NC}"
     # Extract DATABASE_URL from worker.env and use it for RDS connection
-    REQUEUED=$(ssh -i "$SSH_KEY" $SSH_USER@$host 'DATABASE_URL=$(grep "^DATABASE_URL=" /etc/ocpctl/worker.env | cut -d= -f2-); psql "$DATABASE_URL" -t -c "UPDATE jobs SET status = '"'"'PENDING'"'"', started_at = NULL WHERE status = '"'"'RUNNING'"'"' RETURNING id;" 2>/dev/null | grep -o "-" | wc -l | tr -d " "' || echo "0")
+    REQUEUED=$(ssh -i "$SSH_KEY" $SSH_USER@$host 'DATABASE_URL=$(sudo grep "^DATABASE_URL=" /etc/ocpctl/worker.env | cut -d= -f2- | tr -d "\""); psql "$DATABASE_URL" -t -c "UPDATE jobs SET status = '"'"'PENDING'"'"', started_at = NULL WHERE status = '"'"'RUNNING'"'"' RETURNING id;" 2>/dev/null | grep -o "-" | wc -l | tr -d " "' || echo "0")
     if [ "$REQUEUED" -gt 0 ] 2>/dev/null; then
         echo -e "${GREEN}✓ Requeued $REQUEUED job(s) to PENDING status${NC}"
     else
@@ -327,7 +327,7 @@ for host in "${WORKER_HOSTS[@]}"; do
     # Clear any stale job locks from this worker (prevents blocked jobs after restart)
     echo -e "${YELLOW}  Clearing stale job locks...${NC}"
     INSTANCE_ID=$(ssh -i "$SSH_KEY" $SSH_USER@$host 'ec2-metadata --instance-id 2>/dev/null | cut -d " " -f 2' || echo "unknown")
-    LOCKS_CLEARED=$(ssh -i "$SSH_KEY" $SSH_USER@$host 'DATABASE_URL=$(grep "^DATABASE_URL=" /etc/ocpctl/worker.env | cut -d= -f2-); psql "$DATABASE_URL" -t -c "DELETE FROM job_locks WHERE locked_by LIKE '"'"'%'$INSTANCE_ID'%'"'"' RETURNING job_id;" 2>/dev/null | grep -o "-" | wc -l | tr -d " "' || echo "0")
+    LOCKS_CLEARED=$(ssh -i "$SSH_KEY" $SSH_USER@$host 'DATABASE_URL=$(sudo grep "^DATABASE_URL=" /etc/ocpctl/worker.env | cut -d= -f2- | tr -d "\""); psql "$DATABASE_URL" -t -c "DELETE FROM job_locks WHERE locked_by LIKE '"'"'%'$INSTANCE_ID'%'"'"' RETURNING job_id;" 2>/dev/null | grep -o "-" | wc -l | tr -d " "' || echo "0")
     if [ "$LOCKS_CLEARED" -gt 0 ] 2>/dev/null; then
         echo -e "${GREEN}✓ Cleared $LOCKS_CLEARED stale lock(s)${NC}"
     else


### PR DESCRIPTION
## Problem

On a dev deploy the requeue and lock-clear steps printed:

```
grep: /etc/ocpctl/worker.env: Permission denied
  No jobs to requeue
grep: /etc/ocpctl/worker.env: Permission denied
  No locks to clear
```

`worker.env` is mode `0600` owned by `ocpctl`, so the plain `grep` couldn't read it. `DATABASE_URL` came back empty, `psql` failed (suppressed by `2>/dev/null`), and both steps silently fell through to "No jobs/locks" — masking any RUNNING jobs that actually needed requeuing.

## Fix

Match the production `deploy.sh` pattern in both spots:
- `sudo` the `grep`
- strip the surrounding quotes with `tr -d '"'`

## Testing

- `bash -n scripts/deploy-env.sh` clean.
- Verified live: the dev host's `worker.env` is `0600 ocpctl:ocpctl`, which is why the un-sudo'd grep failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)