### PR TITLE
Make metadata.json a required artifact only for OpenShift IPI

### DIFF
--- a/internal/worker/artifact_storage.go
+++ b/internal/worker/artifact_storage.go
@@ -33,8 +33,15 @@ func NewArtifactStorage(ctx context.Context, bucketName string) (*ArtifactStorag
 	}, nil
 }
 
-// UploadClusterArtifacts uploads all cluster artifacts to S3
-func (a *ArtifactStorage) UploadClusterArtifacts(ctx context.Context, workDir, clusterID string) error {
+// UploadClusterArtifacts uploads all cluster artifacts to S3.
+//
+// metadataRequired controls whether a missing metadata.json is a hard failure.
+// metadata.json is produced by openshift-install (OpenShift IPI clusters); managed
+// cluster types (ROSA, EKS, GKE, IKS, ARO, AKS) never generate one, so treating it
+// as required for them fails the whole create at upload even though the cluster
+// installed successfully (#87 exposed this for ROSA). Callers pass true only for
+// OpenShift IPI.
+func (a *ArtifactStorage) UploadClusterArtifacts(ctx context.Context, workDir, clusterID string, metadataRequired bool) error {
 	log.Printf("[ArtifactStorage] Uploading artifacts for cluster %s from %s", clusterID, workDir)
 
 	// List of artifacts to upload with their S3 keys
@@ -55,11 +62,11 @@ func (a *ArtifactStorage) UploadClusterArtifacts(ctx context.Context, workDir, c
 			Required:  false, // Only exists for OpenShift IPI clusters
 		},
 
-		// Metadata
+		// Metadata (only openshift-install/IPI produces metadata.json)
 		{
 			LocalPath: filepath.Join(workDir, "metadata.json"),
 			S3Key:     fmt.Sprintf("clusters/%s/artifacts/metadata.json", clusterID),
-			Required:  true,
+			Required:  metadataRequired,
 		},
 
 		// AWS cleanup manifest (for fast destroy)

--- a/internal/worker/handler_create.go
+++ b/internal/worker/handler_create.go
@@ -338,8 +338,9 @@ func (h *CreateHandler) handleOpenShiftCreate(ctx context.Context, job *types.Jo
 		}
 	}
 
-	// Store artifacts (kubeconfig, metadata, install dir)
-	if err := h.storeArtifacts(ctx, workDir, cluster.ID); err != nil {
+	// Store artifacts (kubeconfig, metadata, install dir). OpenShift IPI produces
+	// metadata.json, so require it here.
+	if err := h.storeArtifacts(ctx, workDir, cluster.ID, true); err != nil {
 		log.Printf("Warning: failed to store artifacts: %v", err)
 	}
 
@@ -584,8 +585,12 @@ func (h *CreateHandler) updateArtifactURIs(ctx context.Context, clusterID string
 	return nil
 }
 
-// storeArtifacts stores cluster artifacts (kubeconfig, logs, metadata)
-func (h *CreateHandler) storeArtifacts(ctx context.Context, workDir, clusterID string) error {
+// storeArtifacts stores cluster artifacts (kubeconfig, logs, metadata).
+//
+// metadataRequired should be true only for OpenShift IPI clusters, which are the
+// only type that produces metadata.json; passing true for managed types (ROSA,
+// EKS, GKE, IKS, ARO, AKS) would fail the upload since they never create it.
+func (h *CreateHandler) storeArtifacts(ctx context.Context, workDir, clusterID string, metadataRequired bool) error {
 	// Create artifact storage client
 	artifactStorage, err := NewArtifactStorage(ctx, h.config.S3BucketName)
 	if err != nil {
@@ -593,7 +598,7 @@ func (h *CreateHandler) storeArtifacts(ctx context.Context, workDir, clusterID s
 	}
 
 	// Upload all artifacts to S3
-	if err := artifactStorage.UploadClusterArtifacts(ctx, workDir, clusterID); err != nil {
+	if err := artifactStorage.UploadClusterArtifacts(ctx, workDir, clusterID, metadataRequired); err != nil {
 		return fmt.Errorf("upload artifacts: %w", err)
 	}
 
@@ -901,8 +906,8 @@ func (h *CreateHandler) handleEKSCreate(ctx context.Context, job *types.Job, clu
 		log.Printf("Warning: failed to store cluster outputs: %v", err)
 	}
 
-	// Store artifacts
-	if err := h.storeArtifacts(ctx, workDir, cluster.ID); err != nil {
+	// Store artifacts (managed cluster type: no metadata.json)
+	if err := h.storeArtifacts(ctx, workDir, cluster.ID, false); err != nil {
 		log.Printf("Warning: failed to store artifacts: %v", err)
 	}
 
@@ -1112,8 +1117,8 @@ func (h *CreateHandler) handleIKSCreate(ctx context.Context, job *types.Job, clu
 		log.Printf("Warning: failed to store cluster outputs: %v", err)
 	}
 
-	// Store artifacts
-	if err := h.storeArtifacts(ctx, workDir, cluster.ID); err != nil {
+	// Store artifacts (managed cluster type: no metadata.json)
+	if err := h.storeArtifacts(ctx, workDir, cluster.ID, false); err != nil {
 		log.Printf("Warning: failed to store artifacts: %v", err)
 	}
 
@@ -1642,7 +1647,7 @@ func (h *CreateHandler) handleROSACreate(ctx context.Context, job *types.Job, cl
 	// Upload artifacts (kubeconfig, metadata) to S3 and rewrite KubeconfigS3URI
 	// to the s3:// location so the UI/API can serve the kubeconfig from any host.
 	// A failure must not leave the cluster READY with a missing kubeconfig.
-	if err := h.storeArtifacts(ctx, workDir, cluster.ID); err != nil {
+	if err := h.storeArtifacts(ctx, workDir, cluster.ID, false); err != nil {
 		return fmt.Errorf("store artifacts: %w", err)
 	}
 

--- a/internal/worker/handler_create_azure.go
+++ b/internal/worker/handler_create_azure.go
@@ -235,7 +235,7 @@ func (h *CreateHandler) handleAROCreate(ctx context.Context, job *types.Job, clu
 	}
 
 	log.Printf("[JOB %s] Uploading artifacts to S3", job.ID)
-	if err := artifactStorage.UploadClusterArtifacts(ctx, workDir, cluster.ID); err != nil {
+	if err := artifactStorage.UploadClusterArtifacts(ctx, workDir, cluster.ID, false); err != nil {
 		return fmt.Errorf("upload artifacts: %w", err)
 	}
 
@@ -256,7 +256,7 @@ func (h *CreateHandler) handleAROCreate(ctx context.Context, job *types.Job, clu
 	}
 
 	// Store artifacts
-	if err := h.storeArtifacts(ctx, workDir, cluster.ID); err != nil {
+	if err := h.storeArtifacts(ctx, workDir, cluster.ID, false); err != nil {
 		log.Printf("Warning: failed to store artifacts: %v", err)
 	}
 
@@ -415,7 +415,7 @@ func (h *CreateHandler) handleAKSCreate(ctx context.Context, job *types.Job, clu
 	}
 
 	log.Printf("[JOB %s] Uploading artifacts to S3", job.ID)
-	if err := artifactStorage.UploadClusterArtifacts(ctx, workDir, cluster.ID); err != nil {
+	if err := artifactStorage.UploadClusterArtifacts(ctx, workDir, cluster.ID, false); err != nil {
 		return fmt.Errorf("upload artifacts: %w", err)
 	}
 
@@ -436,7 +436,7 @@ func (h *CreateHandler) handleAKSCreate(ctx context.Context, job *types.Job, clu
 	}
 
 	// Store artifacts
-	if err := h.storeArtifacts(ctx, workDir, cluster.ID); err != nil {
+	if err := h.storeArtifacts(ctx, workDir, cluster.ID, false); err != nil {
 		log.Printf("Warning: failed to store artifacts: %v", err)
 	}
 


### PR DESCRIPTION
## Problem

ROSA cluster creates were failing at the artifact-upload step even though the cluster installed successfully:

```
store artifacts: upload artifacts: upload required artifact
.../metadata.json: no such file or directory
```

`metadata.json` is produced by `openshift-install` for OpenShift **IPI** clusters. Managed cluster types (ROSA, EKS, IKS, GKE, ARO, AKS) never generate one, but `UploadClusterArtifacts` marked it `Required: true` unconditionally.

This was previously masked: pre-#87, ROSA creates died earlier at `rosa create admin`. Fixing that admin idempotency (#87) exposed this downstream failure. Observed on prod cluster `tsanders-rosa-testing-abc` — the cluster reached ROSA `ready` but ocpctl marked the job FAILED.

## Fix

Thread a `metadataRequired bool` from `storeArtifacts` into `UploadClusterArtifacts`. Only OpenShift IPI passes `true`; all managed types pass `false`, so a missing `metadata.json` is no longer a hard failure for them (it's still uploaded when present).

## Testing

- `go build ./...` clean
- `internal/worker` and `internal/installer` tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)