### PR TITLE
Extend ROSA admin oc login retry window for OAuth propagation

### DIFF
--- a/internal/installer/rosa.go
+++ b/internal/installer/rosa.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log"
 	"os"
 	"os/exec"
 	"regexp"
@@ -615,11 +616,18 @@ func (r *ROSAInstaller) GetKubeconfig(ctx context.Context, clusterName, outputPa
 	username := parts[4]
 	password := parts[6]
 
-	// Run oc login with kubeconfig output (with retry logic)
-	// The cluster API may not be immediately accessible after cluster becomes ready
+	// Run oc login with kubeconfig output (with retry logic).
+	//
+	// A freshly created cluster-admin is not immediately usable: the credential
+	// must propagate to the cluster's OAuth server before it authenticates, and
+	// rosa itself warns "It may take several minutes for this access to become
+	// active." Until then oc login returns 401 Unauthorized. The previous 5x10s
+	// (~50s) window landed right on the edge of that propagation time, so logins
+	// failed intermittently even though the cluster and admin were both healthy.
+	// Retry for ~5 minutes to comfortably cover the activation delay.
 	var lastErr error
-	maxRetries := 5
-	retryDelay := 10 * time.Second
+	maxRetries := 20
+	retryDelay := 15 * time.Second
 
 	for attempt := 1; attempt <= maxRetries; attempt++ {
 		ocCmd := exec.CommandContext(ctx, "oc", "login", apiURL,
@@ -628,14 +636,23 @@ func (r *ROSAInstaller) GetKubeconfig(ctx context.Context, clusterName, outputPa
 			"--kubeconfig", outputPath,
 			"--insecure-skip-tls-verify")
 
-		var ocStderr bytes.Buffer
+		// oc login writes the "Login failed (401 Unauthorized)" message to stdout,
+		// not stderr, so capture both to produce a useful error on final failure.
+		var ocStdout, ocStderr bytes.Buffer
+		ocCmd.Stdout = &ocStdout
 		ocCmd.Stderr = &ocStderr
 
 		if err := ocCmd.Run(); err != nil {
-			lastErr = fmt.Errorf("oc login failed (attempt %d/%d): %w\nStderr: %s", attempt, maxRetries, err, ocStderr.String())
+			lastErr = fmt.Errorf("oc login failed (attempt %d/%d): %w\nStdout: %s\nStderr: %s",
+				attempt, maxRetries, err, strings.TrimSpace(ocStdout.String()), strings.TrimSpace(ocStderr.String()))
+			log.Printf("ROSA admin oc login not yet ready for %s (attempt %d/%d), retrying in %s", clusterName, attempt, maxRetries, retryDelay)
 			if attempt < maxRetries {
-				// Wait before retrying
-				time.Sleep(retryDelay)
+				// Wait before retrying, but bail promptly if the job is cancelled.
+				select {
+				case <-ctx.Done():
+					return nil, fmt.Errorf("oc login cancelled while waiting for admin to activate: %w", ctx.Err())
+				case <-time.After(retryDelay):
+				}
 				continue
 			}
 			// Final attempt failed
@@ -643,6 +660,7 @@ func (r *ROSAInstaller) GetKubeconfig(ctx context.Context, clusterName, outputPa
 		}
 
 		// Success
+		log.Printf("ROSA admin oc login succeeded for %s on attempt %d/%d", clusterName, attempt, maxRetries)
 		break
 	}
 


### PR DESCRIPTION
## Problem

ROSA creates were failing intermittently right after the cluster reached `ready`:

```
get ROSA admin credentials/kubeconfig: oc login failed (attempt 5/5): exit status 1
```

The cluster and the cluster-admin were both healthy. The real error (captured during diagnosis) is a **401 Unauthorized** — a freshly created cluster-admin takes time to propagate to the cluster's OAuth server. `rosa create admin` itself warns: *"It may take several minutes for this access to become active."*

The retry window was 5 × 10s (~50s), right on the edge of that propagation time. Measured activation was ~31s in one run and >50s in the failing job — hence the flakiness.

This bug sits downstream of the #87 admin-idempotency fix (admin is recovered correctly) and upstream of artifact upload (never reached).

## Fix

- Extend the `oc login` retry window to 20 × 15s (~5 min) to comfortably cover the activation delay.
- Capture **stdout** in addition to stderr — `oc` writes `Login failed (401 Unauthorized)` to stdout, which is why the prior error surfaced a blank `Stderr:`.
- Make the inter-attempt wait context-aware so a cancelled job bails promptly.
- Log each attempt so the retries are visible in the worker journal.

## Testing

- `go build ./...` clean; `internal/installer` tests pass.
- Reproduced the 401 on a live prod ROSA cluster and confirmed the login succeeds once the admin activates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)