### PR TITLE
Add AWS quota/capacity pre-flight check before cluster create

### DIFF
--- a/docs/features/QUOTA_PREFLIGHT.md
+++ b/docs/features/QUOTA_PREFLIGHT.md
@@ -1,0 +1,66 @@
+# AWS Quota & Capacity Pre-flight
+
+**Issue:** [#100](https://github.com/tsanders-rh/ocpctl/issues/100)
+
+## Problem
+
+Before this check, the AWS pre-flight (`internal/worker/preflight_aws.go`,
+`CheckInstanceTypeAvailability`) validated only that the requested instance
+types were offered across enough availability zones. It did **not** look at
+account service quotas, so a create could pass pre-flight and then fail deep in
+CAPI provisioning when a shared-account quota was exhausted.
+
+This is exactly what bit nadeem on 2026-08-19: `us-east-1` had hit its
+Gateway-VPC-endpoint limit (`VpcEndpointLimitExceeded`) and the failure only
+surfaced ~15 minutes into the create, after infra was already being built.
+
+## What it checks
+
+`CheckQuotas` (`internal/worker/quota_preflight.go`) compares, for the target
+region, **applied quota vs. current usage vs. this cluster's need** for the
+four quotas every OpenShift IPI cluster consumes:
+
+| Quota | Code | Need per cluster |
+|-------|------|------------------|
+| Gateway VPC endpoints per Region | `L-1B52E74A` | 1 (S3 gateway endpoint) |
+| VPCs per Region | `L-F678F1CE` | 1 |
+| Elastic IPs per Region | `L-0263D0A3` | 1 per AZ (NAT gateway) |
+| Running On-Demand Standard vCPUs | `L-1216C47A` | control-plane + workers + 1 bootstrap |
+
+Applied quota comes from `servicequotas:GetServiceQuota`; usage is counted with
+EC2 `Describe*` calls. The vCPU need is derived from the profile's control-plane
+and worker instance types (looked up via `DescribeInstanceTypes`).
+
+## Design principles
+
+- **Only blocks on a confirmed shortfall.** If `need > free` for any quota, the
+  create fails fast with a `PreflightCheckError` (no retry) listing every
+  short quota and remediation steps.
+- **Never a new source of outages.** Any lookup that errors — missing IAM
+  permission, throttling, an unrecognized quota, an empty value — is logged and
+  **skipped**, not treated as a failure. A degraded quota check falls back to
+  the old behavior (create proceeds).
+- **vCPU check is best-effort.** It only applies to Standard-family instance
+  types (A, C, D, H, I, M, R, T, Z), which is what the `L-1216C47A` quota
+  counts. Non-Standard families (e.g. GPU `g5`/`p4d`) skip the vCPU check with a
+  warning rather than compare against the wrong quota.
+
+## IAM permissions
+
+All required permissions are already granted to the worker role — no policy
+change was needed for this feature:
+
+- `servicequotas:GetServiceQuota`
+- `ec2:DescribeVpcEndpoints`, `ec2:DescribeVpcs`, `ec2:DescribeAddresses`,
+  `ec2:DescribeInstances`, `ec2:DescribeInstanceTypes`
+
+See `deploy/iam-policy-worker-full.json` (Sid `ServiceQuotasRead`) and
+`terraform/dev/openshift-provisioning-policy.json`.
+
+## Tests
+
+`internal/worker/quota_preflight_test.go` uses mocked `ec2QuotaAPI` /
+`quotasAPI` implementations to cover: sufficient headroom passes, gateway-
+endpoint exhaustion blocks, Standard vCPU shortfall blocks, quota-lookup failure
+degrades gracefully, usage-lookup failure degrades gracefully, and the vCPU
+check is skipped for non-Standard families.

--- a/go.mod
+++ b/go.mod
@@ -36,6 +36,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/route53 v1.62.2
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.96.2
 	github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.41.4
+	github.com/aws/aws-sdk-go-v2/service/servicequotas v1.34.2
 	github.com/aws/aws-sdk-go-v2/service/sts v1.41.7
 	github.com/golang-jwt/jwt/v5 v5.3.1
 	github.com/google/uuid v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -64,6 +64,8 @@ github.com/aws/aws-sdk-go-v2/service/s3 v1.96.2 h1:M1A9AjcFwlxTLuf0Faj88L8Iqw0n/
 github.com/aws/aws-sdk-go-v2/service/s3 v1.96.2/go.mod h1:KsdTV6Q9WKUZm2mNJnUFmIoXfZux91M3sr/a4REX8e0=
 github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.41.4 h1:9aZbO86sraeCIHHCpZhxwN9tnVy9POkSKzi4/TpT54A=
 github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.41.4/go.mod h1:cxiXDhEzIq7Xx1BtmC4lGBK3SwAZ79+EUWiKawYHo14=
+github.com/aws/aws-sdk-go-v2/service/servicequotas v1.34.2 h1:sm6NBL6B4zM9NwDukeXb9j6/aYRrBWtMjEwmSpc+Bss=
+github.com/aws/aws-sdk-go-v2/service/servicequotas v1.34.2/go.mod h1:5X/vFNucNV7Ab1dqsncCnenSs/AbZH8cv8I30feCpdg=
 github.com/aws/aws-sdk-go-v2/service/signin v1.0.6 h1:MzORe+J94I+hYu2a6XmV5yC9huoTv8NRcCrUNedDypQ=
 github.com/aws/aws-sdk-go-v2/service/signin v1.0.6/go.mod h1:hXzcHLARD7GeWnifd8j9RWqtfIgxj4/cAtIVIK7hg8g=
 github.com/aws/aws-sdk-go-v2/service/sso v1.30.11 h1:7oGD8KPfBOJGXiCoRKrrrQkbvCp8N++u36hrLMPey6o=

--- a/internal/worker/handler_create.go
+++ b/internal/worker/handler_create.go
@@ -117,6 +117,11 @@ func (h *CreateHandler) handleOpenShiftCreate(ctx context.Context, job *types.Jo
 				// Use PreflightCheckError to prevent retries and provide clear error code
 				return types.NewPreflightCheckError("AWS capacity pre-flight check failed: %v", err)
 			}
+			// Quota headroom check (gateway VPC endpoints, VPCs, EIPs, vCPUs).
+			// Only blocks on a confirmed shortfall; lookup errors degrade to warnings.
+			if err := checker.CheckQuotas(ctx, prof); err != nil {
+				return types.NewPreflightCheckError("AWS quota pre-flight check failed: %v", err)
+			}
 		}
 	} else if cluster.Platform == types.PlatformGCP {
 		// GCP-specific pre-flight checks (machine type availability)

--- a/internal/worker/preflight_aws.go
+++ b/internal/worker/preflight_aws.go
@@ -11,13 +11,15 @@ import (
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"github.com/aws/aws-sdk-go-v2/service/servicequotas"
 	"github.com/tsanders-rh/ocpctl/internal/profile"
 )
 
 // AWSPreflightChecker validates AWS resource availability before cluster creation
 type AWSPreflightChecker struct {
-	region    string
-	ec2Client *ec2.Client
+	region       string
+	ec2Client    *ec2.Client
+	quotasClient *servicequotas.Client
 }
 
 // NewAWSPreflightChecker creates a new AWS pre-flight checker
@@ -28,8 +30,9 @@ func NewAWSPreflightChecker(ctx context.Context, region string) (*AWSPreflightCh
 	}
 
 	return &AWSPreflightChecker{
-		region:    region,
-		ec2Client: ec2.NewFromConfig(cfg),
+		region:       region,
+		ec2Client:    ec2.NewFromConfig(cfg),
+		quotasClient: servicequotas.NewFromConfig(cfg),
 	}, nil
 }
 

--- a/internal/worker/quota_preflight.go
+++ b/internal/worker/quota_preflight.go
@@ -1,0 +1,397 @@
+package worker
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"math"
+	"sort"
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"github.com/aws/aws-sdk-go-v2/service/servicequotas"
+	"github.com/tsanders-rh/ocpctl/internal/profile"
+)
+
+// AWS Service Quotas codes for the resources every OpenShift IPI cluster consumes.
+// See https://docs.aws.amazon.com/general/latest/gr/aws_service_limits.html
+const (
+	quotaServiceVPC = "vpc"
+	quotaServiceEC2 = "ec2"
+
+	// Gateway VPC endpoints per Region (each cluster VPC gets one S3 gateway endpoint).
+	quotaCodeGatewayVPCEndpoints = "L-1B52E74A"
+	// VPCs per Region.
+	quotaCodeVPCsPerRegion = "L-F678F1CE"
+	// EC2-VPC Elastic IPs per Region (NAT gateways consume one each).
+	quotaCodeElasticIPs = "L-0263D0A3"
+	// Running On-Demand Standard (A, C, D, H, I, M, R, T, Z) instances, measured in vCPUs.
+	quotaCodeStandardVCPUs = "L-1216C47A"
+)
+
+// ec2QuotaAPI is the subset of the EC2 client used by the quota preflight. It is
+// satisfied by *ec2.Client and mocked in tests.
+type ec2QuotaAPI interface {
+	DescribeVpcEndpoints(context.Context, *ec2.DescribeVpcEndpointsInput, ...func(*ec2.Options)) (*ec2.DescribeVpcEndpointsOutput, error)
+	DescribeVpcs(context.Context, *ec2.DescribeVpcsInput, ...func(*ec2.Options)) (*ec2.DescribeVpcsOutput, error)
+	DescribeAddresses(context.Context, *ec2.DescribeAddressesInput, ...func(*ec2.Options)) (*ec2.DescribeAddressesOutput, error)
+	DescribeInstances(context.Context, *ec2.DescribeInstancesInput, ...func(*ec2.Options)) (*ec2.DescribeInstancesOutput, error)
+	DescribeInstanceTypes(context.Context, *ec2.DescribeInstanceTypesInput, ...func(*ec2.Options)) (*ec2.DescribeInstanceTypesOutput, error)
+}
+
+// quotasAPI is the subset of the Service Quotas client used by the quota
+// preflight. Satisfied by *servicequotas.Client and mocked in tests.
+type quotasAPI interface {
+	GetServiceQuota(context.Context, *servicequotas.GetServiceQuotaInput, ...func(*servicequotas.Options)) (*servicequotas.GetServiceQuotaOutput, error)
+}
+
+// standardVCPUFamilies are the instance-family first letters counted by the
+// "Running On-Demand Standard instances" quota (L-1216C47A).
+var standardVCPUFamilies = map[byte]bool{
+	'a': true, 'c': true, 'd': true, 'h': true,
+	'i': true, 'm': true, 'r': true, 't': true, 'z': true,
+}
+
+// isStandardFamily reports whether an instance type belongs to a Standard family.
+func isStandardFamily(instanceType string) bool {
+	if instanceType == "" {
+		return false
+	}
+	return standardVCPUFamilies[instanceType[0]]
+}
+
+// quotaRequirement describes one quota to validate: how many units this cluster
+// needs and how to count what is already in use.
+type quotaRequirement struct {
+	label       string
+	serviceCode string
+	quotaCode   string
+	needed      int
+	getUsage    func(context.Context) (int, error)
+}
+
+// CheckQuotas validates that the target region has enough headroom in the AWS
+// service quotas every cluster consumes (gateway VPC endpoints, VPCs, Elastic
+// IPs, and Standard vCPUs) before provisioning begins.
+//
+// It fails ONLY on a confirmed shortfall. Any lookup that errors (missing
+// permission, throttling, an unrecognized quota) is logged and skipped so the
+// preflight can never become a new source of outages.
+func (c *AWSPreflightChecker) CheckQuotas(ctx context.Context, prof *profile.Profile) error {
+	if c.quotasClient == nil {
+		log.Printf("Pre-flight quota check: no Service Quotas client configured, skipping")
+		return nil
+	}
+	return runQuotaChecks(ctx, c.region, c.ec2Client, c.quotasClient, prof)
+}
+
+// runQuotaChecks is the testable core of CheckQuotas.
+func runQuotaChecks(ctx context.Context, region string, ec2c ec2QuotaAPI, q quotasAPI, prof *profile.Profile) error {
+	reqs := buildQuotaRequirements(ctx, ec2c, prof)
+
+	var shortfalls []string
+	for _, r := range reqs {
+		applied, err := getAppliedQuota(ctx, q, r.serviceCode, r.quotaCode)
+		if err != nil {
+			log.Printf("Pre-flight quota check: skipping %q (quota lookup failed: %v)", r.label, err)
+			continue
+		}
+		usage, err := r.getUsage(ctx)
+		if err != nil {
+			log.Printf("Pre-flight quota check: skipping %q (usage lookup failed: %v)", r.label, err)
+			continue
+		}
+
+		free := applied - usage
+		log.Printf("Pre-flight quota check: %s — usage %d / quota %d, need %d (%d free)",
+			r.label, usage, applied, r.needed, free)
+
+		if r.needed > free {
+			shortfalls = append(shortfalls, fmt.Sprintf(
+				"  • %s: %d/%d used, need %d free (only %d available)",
+				r.label, usage, applied, r.needed, max(free, 0)))
+		}
+	}
+
+	if len(shortfalls) > 0 {
+		return formatQuotaError(region, shortfalls)
+	}
+	return nil
+}
+
+// buildQuotaRequirements assembles the list of quotas to check for this profile.
+// The vCPU requirement is only added when it can be computed for Standard-family
+// instance types; otherwise it is skipped with a warning.
+func buildQuotaRequirements(ctx context.Context, ec2c ec2QuotaAPI, prof *profile.Profile) []quotaRequirement {
+	reqs := []quotaRequirement{
+		{
+			label:       "Gateway VPC endpoints per Region",
+			serviceCode: quotaServiceVPC,
+			quotaCode:   quotaCodeGatewayVPCEndpoints,
+			needed:      1, // one S3 gateway endpoint per cluster VPC
+			getUsage:    func(ctx context.Context) (int, error) { return countGatewayVPCEndpoints(ctx, ec2c) },
+		},
+		{
+			label:       "VPCs per Region",
+			serviceCode: quotaServiceVPC,
+			quotaCode:   quotaCodeVPCsPerRegion,
+			needed:      1,
+			getUsage:    func(ctx context.Context) (int, error) { return countVPCs(ctx, ec2c) },
+		},
+		{
+			label:       "Elastic IPs per Region",
+			serviceCode: quotaServiceEC2,
+			quotaCode:   quotaCodeElasticIPs,
+			needed:      estimateAZCount(prof), // one EIP per NAT gateway (one per AZ)
+			getUsage:    func(ctx context.Context) (int, error) { return countElasticIPs(ctx, ec2c) },
+		},
+	}
+
+	if need, ok := computeVCPUNeed(ctx, ec2c, prof); ok {
+		reqs = append(reqs, quotaRequirement{
+			label:       "Running On-Demand Standard vCPUs",
+			serviceCode: quotaServiceEC2,
+			quotaCode:   quotaCodeStandardVCPUs,
+			needed:      need,
+			getUsage:    func(ctx context.Context) (int, error) { return countStandardVCPUsInUse(ctx, ec2c) },
+		})
+	} else {
+		log.Printf("Pre-flight quota check: skipping vCPU check (non-Standard instance family or lookup unavailable)")
+	}
+
+	return reqs
+}
+
+// getAppliedQuota returns the currently applied quota value, rounded down.
+func getAppliedQuota(ctx context.Context, q quotasAPI, serviceCode, quotaCode string) (int, error) {
+	out, err := q.GetServiceQuota(ctx, &servicequotas.GetServiceQuotaInput{
+		ServiceCode: aws.String(serviceCode),
+		QuotaCode:   aws.String(quotaCode),
+	})
+	if err != nil {
+		return 0, fmt.Errorf("get service quota %s/%s: %w", serviceCode, quotaCode, err)
+	}
+	if out.Quota == nil || out.Quota.Value == nil {
+		return 0, fmt.Errorf("get service quota %s/%s: empty value", serviceCode, quotaCode)
+	}
+	return int(math.Floor(*out.Quota.Value)), nil
+}
+
+// countGatewayVPCEndpoints counts gateway-type VPC endpoints in the region.
+func countGatewayVPCEndpoints(ctx context.Context, ec2c ec2QuotaAPI) (int, error) {
+	count := 0
+	var token *string
+	for {
+		out, err := ec2c.DescribeVpcEndpoints(ctx, &ec2.DescribeVpcEndpointsInput{
+			Filters: []ec2types.Filter{{
+				Name:   aws.String("vpc-endpoint-type"),
+				Values: []string{string(ec2types.VpcEndpointTypeGateway)},
+			}},
+			NextToken: token,
+		})
+		if err != nil {
+			return 0, err
+		}
+		count += len(out.VpcEndpoints)
+		if out.NextToken == nil || *out.NextToken == "" {
+			return count, nil
+		}
+		token = out.NextToken
+	}
+}
+
+// countVPCs counts all VPCs in the region (the quota includes the default VPC).
+func countVPCs(ctx context.Context, ec2c ec2QuotaAPI) (int, error) {
+	count := 0
+	var token *string
+	for {
+		out, err := ec2c.DescribeVpcs(ctx, &ec2.DescribeVpcsInput{NextToken: token})
+		if err != nil {
+			return 0, err
+		}
+		count += len(out.Vpcs)
+		if out.NextToken == nil || *out.NextToken == "" {
+			return count, nil
+		}
+		token = out.NextToken
+	}
+}
+
+// countElasticIPs counts allocated Elastic IPs in the region.
+func countElasticIPs(ctx context.Context, ec2c ec2QuotaAPI) (int, error) {
+	out, err := ec2c.DescribeAddresses(ctx, &ec2.DescribeAddressesInput{})
+	if err != nil {
+		return 0, err
+	}
+	return len(out.Addresses), nil
+}
+
+// countStandardVCPUsInUse sums the vCPUs of running/pending Standard-family
+// instances in the region.
+func countStandardVCPUsInUse(ctx context.Context, ec2c ec2QuotaAPI) (int, error) {
+	typeCounts := map[string]int{}
+	var token *string
+	for {
+		out, err := ec2c.DescribeInstances(ctx, &ec2.DescribeInstancesInput{
+			Filters: []ec2types.Filter{{
+				Name:   aws.String("instance-state-name"),
+				Values: []string{"running", "pending"},
+			}},
+			NextToken: token,
+		})
+		if err != nil {
+			return 0, err
+		}
+		for _, res := range out.Reservations {
+			for _, inst := range res.Instances {
+				it := string(inst.InstanceType)
+				if isStandardFamily(it) {
+					typeCounts[it]++
+				}
+			}
+		}
+		if out.NextToken == nil || *out.NextToken == "" {
+			break
+		}
+		token = out.NextToken
+	}
+
+	if len(typeCounts) == 0 {
+		return 0, nil
+	}
+
+	vcpus, err := getVCPUsPerType(ctx, ec2c, mapKeys(typeCounts))
+	if err != nil {
+		return 0, err
+	}
+	total := 0
+	for it, n := range typeCounts {
+		total += vcpus[it] * n
+	}
+	return total, nil
+}
+
+// computeVCPUNeed returns the vCPUs this cluster will consume (control plane +
+// workers + one bootstrap node). The second return is false when the check does
+// not apply — a non-Standard instance family, or an instance-type lookup error.
+func computeVCPUNeed(ctx context.Context, ec2c ec2QuotaAPI, prof *profile.Profile) (int, bool) {
+	cpType, cpReplicas := "", 0
+	if prof.Compute.ControlPlane != nil {
+		cpType = prof.Compute.ControlPlane.InstanceType
+		cpReplicas = prof.Compute.ControlPlane.Replicas
+	}
+	workerType, workerReplicas := "", 0
+	if prof.Compute.Workers != nil {
+		workerType = prof.Compute.Workers.InstanceType
+		workerReplicas = prof.Compute.Workers.Replicas
+	}
+
+	// The Standard vCPU quota only counts Standard-family instances. If any
+	// requested type is outside that group we cannot compute usage against the
+	// same quota, so skip rather than risk a wrong verdict.
+	for _, t := range []string{cpType, workerType} {
+		if t != "" && !isStandardFamily(t) {
+			return 0, false
+		}
+	}
+	if cpType == "" && workerType == "" {
+		return 0, false
+	}
+
+	typeSet := map[string]bool{}
+	if cpType != "" {
+		typeSet[cpType] = true
+	}
+	if workerType != "" {
+		typeSet[workerType] = true
+	}
+	types := make([]string, 0, len(typeSet))
+	for t := range typeSet {
+		types = append(types, t)
+	}
+	vcpus, err := getVCPUsPerType(ctx, ec2c, types)
+	if err != nil {
+		return 0, false
+	}
+
+	need := 0
+	if cpType != "" {
+		need += vcpus[cpType] * cpReplicas
+		need += vcpus[cpType] // bootstrap node uses a control-plane-sized instance
+	}
+	if workerType != "" {
+		need += vcpus[workerType] * workerReplicas
+	}
+	if need == 0 {
+		return 0, false
+	}
+	return need, true
+}
+
+// getVCPUsPerType returns the default vCPU count for each instance type.
+func getVCPUsPerType(ctx context.Context, ec2c ec2QuotaAPI, types []string) (map[string]int, error) {
+	result := map[string]int{}
+	if len(types) == 0 {
+		return result, nil
+	}
+	sort.Strings(types)
+
+	instanceTypes := make([]ec2types.InstanceType, 0, len(types))
+	for _, t := range types {
+		instanceTypes = append(instanceTypes, ec2types.InstanceType(t))
+	}
+
+	out, err := ec2c.DescribeInstanceTypes(ctx, &ec2.DescribeInstanceTypesInput{
+		InstanceTypes: instanceTypes,
+	})
+	if err != nil {
+		return nil, err
+	}
+	for _, it := range out.InstanceTypes {
+		if it.VCpuInfo != nil && it.VCpuInfo.DefaultVCpus != nil {
+			result[string(it.InstanceType)] = int(*it.VCpuInfo.DefaultVCpus)
+		}
+	}
+	return result, nil
+}
+
+// estimateAZCount estimates how many availability zones (and therefore NAT
+// gateways / Elastic IPs) the cluster will use: one for single-node, otherwise
+// the standard three.
+func estimateAZCount(prof *profile.Profile) int {
+	cp := 3
+	if prof.Compute.ControlPlane != nil && prof.Compute.ControlPlane.Replicas > 0 {
+		cp = prof.Compute.ControlPlane.Replicas
+	}
+	if cp > 3 {
+		cp = 3
+	}
+	if cp < 1 {
+		cp = 1
+	}
+	return cp
+}
+
+// formatQuotaError builds a user-facing error listing the quotas without headroom.
+func formatQuotaError(region string, shortfalls []string) error {
+	var msg strings.Builder
+	msg.WriteString("❌ AWS Quota Pre-flight Check Failed\n\n")
+	msg.WriteString(fmt.Sprintf("The region %s does not have enough quota headroom to create this cluster:\n\n", region))
+	msg.WriteString(strings.Join(shortfalls, "\n"))
+	msg.WriteString("\n\nRecommendations:\n")
+	msg.WriteString("  1. Create the cluster in a different region (each region has its own quotas)\n")
+	msg.WriteString("  2. Free capacity by destroying unused clusters or cleaning up orphaned resources\n")
+	msg.WriteString("  3. Request a Service Quotas increase for the limits above\n")
+	return fmt.Errorf("%s", msg.String())
+}
+
+// mapKeys returns the keys of a string-keyed map.
+func mapKeys(m map[string]int) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	return keys
+}

--- a/internal/worker/quota_preflight_test.go
+++ b/internal/worker/quota_preflight_test.go
@@ -1,0 +1,269 @@
+package worker
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"github.com/aws/aws-sdk-go-v2/service/servicequotas"
+	sqtypes "github.com/aws/aws-sdk-go-v2/service/servicequotas/types"
+	"github.com/tsanders-rh/ocpctl/internal/profile"
+)
+
+// --- mocks ---
+
+type mockEC2 struct {
+	endpoints  int
+	vpcs       int
+	eips       int
+	instances  map[string]int   // instance type -> running count
+	vcpuByType map[string]int32 // instance type -> default vCPUs
+
+	endpointsErr error
+	vpcsErr      error
+	eipsErr      error
+	instancesErr error
+	instTypesErr error
+}
+
+func (m *mockEC2) DescribeVpcEndpoints(_ context.Context, _ *ec2.DescribeVpcEndpointsInput, _ ...func(*ec2.Options)) (*ec2.DescribeVpcEndpointsOutput, error) {
+	if m.endpointsErr != nil {
+		return nil, m.endpointsErr
+	}
+	return &ec2.DescribeVpcEndpointsOutput{VpcEndpoints: make([]ec2types.VpcEndpoint, m.endpoints)}, nil
+}
+
+func (m *mockEC2) DescribeVpcs(_ context.Context, _ *ec2.DescribeVpcsInput, _ ...func(*ec2.Options)) (*ec2.DescribeVpcsOutput, error) {
+	if m.vpcsErr != nil {
+		return nil, m.vpcsErr
+	}
+	return &ec2.DescribeVpcsOutput{Vpcs: make([]ec2types.Vpc, m.vpcs)}, nil
+}
+
+func (m *mockEC2) DescribeAddresses(_ context.Context, _ *ec2.DescribeAddressesInput, _ ...func(*ec2.Options)) (*ec2.DescribeAddressesOutput, error) {
+	if m.eipsErr != nil {
+		return nil, m.eipsErr
+	}
+	return &ec2.DescribeAddressesOutput{Addresses: make([]ec2types.Address, m.eips)}, nil
+}
+
+func (m *mockEC2) DescribeInstances(_ context.Context, _ *ec2.DescribeInstancesInput, _ ...func(*ec2.Options)) (*ec2.DescribeInstancesOutput, error) {
+	if m.instancesErr != nil {
+		return nil, m.instancesErr
+	}
+	var insts []ec2types.Instance
+	for t, n := range m.instances {
+		for i := 0; i < n; i++ {
+			insts = append(insts, ec2types.Instance{InstanceType: ec2types.InstanceType(t)})
+		}
+	}
+	return &ec2.DescribeInstancesOutput{
+		Reservations: []ec2types.Reservation{{Instances: insts}},
+	}, nil
+}
+
+func (m *mockEC2) DescribeInstanceTypes(_ context.Context, in *ec2.DescribeInstanceTypesInput, _ ...func(*ec2.Options)) (*ec2.DescribeInstanceTypesOutput, error) {
+	if m.instTypesErr != nil {
+		return nil, m.instTypesErr
+	}
+	var out ec2.DescribeInstanceTypesOutput
+	for _, it := range in.InstanceTypes {
+		v, ok := m.vcpuByType[string(it)]
+		if !ok {
+			continue
+		}
+		out.InstanceTypes = append(out.InstanceTypes, ec2types.InstanceTypeInfo{
+			InstanceType: it,
+			VCpuInfo:     &ec2types.VCpuInfo{DefaultVCpus: aws.Int32(v)},
+		})
+	}
+	return &out, nil
+}
+
+type mockQuotas struct {
+	values map[string]float64 // "service/code" -> applied value
+	err    error
+}
+
+func (m *mockQuotas) GetServiceQuota(_ context.Context, in *servicequotas.GetServiceQuotaInput, _ ...func(*servicequotas.Options)) (*servicequotas.GetServiceQuotaOutput, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	key := aws.ToString(in.ServiceCode) + "/" + aws.ToString(in.QuotaCode)
+	v, ok := m.values[key]
+	if !ok {
+		return nil, errors.New("quota not found: " + key)
+	}
+	return &servicequotas.GetServiceQuotaOutput{
+		Quota: &sqtypes.ServiceQuota{Value: aws.Float64(v)},
+	}, nil
+}
+
+// generous quotas so nothing is the bottleneck unless a test overrides it.
+func generousQuotas() map[string]float64 {
+	return map[string]float64{
+		quotaServiceVPC + "/" + quotaCodeGatewayVPCEndpoints: 50,
+		quotaServiceVPC + "/" + quotaCodeVPCsPerRegion:       50,
+		quotaServiceEC2 + "/" + quotaCodeElasticIPs:          50,
+		quotaServiceEC2 + "/" + quotaCodeStandardVCPUs:       1000,
+	}
+}
+
+func snoProfile() *profile.Profile {
+	return &profile.Profile{
+		Compute: profile.ComputeConfig{
+			ControlPlane: &profile.ControlPlaneConfig{Replicas: 1, InstanceType: "m6i.2xlarge"},
+			Workers:      &profile.WorkersConfig{Replicas: 0},
+		},
+	}
+}
+
+func standardProfile() *profile.Profile {
+	return &profile.Profile{
+		Compute: profile.ComputeConfig{
+			ControlPlane: &profile.ControlPlaneConfig{Replicas: 3, InstanceType: "m6i.xlarge"},
+			Workers:      &profile.WorkersConfig{Replicas: 3, InstanceType: "m6i.2xlarge"},
+		},
+	}
+}
+
+// --- tests ---
+
+func TestRunQuotaChecks(t *testing.T) {
+	vcpu := map[string]int32{"m6i.xlarge": 4, "m6i.2xlarge": 8}
+
+	tests := []struct {
+		name      string
+		ec2       *mockEC2
+		quotas    *mockQuotas
+		prof      *profile.Profile
+		wantErr   bool
+		errSubstr string
+	}{
+		{
+			name:   "plenty of headroom passes",
+			ec2:    &mockEC2{endpoints: 5, vpcs: 5, eips: 2, vcpuByType: vcpu},
+			quotas: &mockQuotas{values: generousQuotas()},
+			prof:   snoProfile(),
+		},
+		{
+			name:      "gateway endpoint exhaustion blocks",
+			ec2:       &mockEC2{endpoints: 20, vpcs: 5, eips: 2, vcpuByType: vcpu},
+			quotas:    &mockQuotas{values: map[string]float64{quotaServiceVPC + "/" + quotaCodeGatewayVPCEndpoints: 20, quotaServiceVPC + "/" + quotaCodeVPCsPerRegion: 50, quotaServiceEC2 + "/" + quotaCodeElasticIPs: 50, quotaServiceEC2 + "/" + quotaCodeStandardVCPUs: 1000}},
+			prof:      snoProfile(),
+			wantErr:   true,
+			errSubstr: "Gateway VPC endpoints",
+		},
+		{
+			name:      "vcpu shortfall blocks for standard family",
+			ec2:       &mockEC2{endpoints: 1, vpcs: 1, eips: 0, instances: map[string]int{"m6i.2xlarge": 3}, vcpuByType: vcpu},
+			quotas:    &mockQuotas{values: map[string]float64{quotaServiceVPC + "/" + quotaCodeGatewayVPCEndpoints: 50, quotaServiceVPC + "/" + quotaCodeVPCsPerRegion: 50, quotaServiceEC2 + "/" + quotaCodeElasticIPs: 50, quotaServiceEC2 + "/" + quotaCodeStandardVCPUs: 40}},
+			prof:      standardProfile(), // need = 4*3 + 4 (bootstrap) + 8*3 = 40; usage = 24 -> 64 > 40
+			wantErr:   true,
+			errSubstr: "Standard vCPUs",
+		},
+		{
+			name:   "quota lookup failure degrades gracefully (no block)",
+			ec2:    &mockEC2{endpoints: 99, vpcs: 99, eips: 99, vcpuByType: vcpu},
+			quotas: &mockQuotas{err: errors.New("AccessDenied")},
+			prof:   snoProfile(),
+		},
+		{
+			name:   "usage lookup failure degrades gracefully (no block)",
+			ec2:    &mockEC2{endpointsErr: errors.New("throttled"), vpcs: 1, eips: 0, vcpuByType: vcpu},
+			quotas: &mockQuotas{values: generousQuotas()},
+			prof:   snoProfile(),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := runQuotaChecks(context.Background(), "us-east-1", tt.ec2, tt.quotas, tt.prof)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				if tt.errSubstr != "" && !strings.Contains(err.Error(), tt.errSubstr) {
+					t.Fatalf("error %q does not contain %q", err.Error(), tt.errSubstr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("expected no error, got: %v", err)
+			}
+		})
+	}
+}
+
+func TestVCPUCheckSkippedForNonStandardFamily(t *testing.T) {
+	// Worker uses a GPU family (g5) -> vCPU check must be skipped even though the
+	// Standard vCPU quota is set impossibly low.
+	prof := &profile.Profile{
+		Compute: profile.ComputeConfig{
+			ControlPlane: &profile.ControlPlaneConfig{Replicas: 3, InstanceType: "m6i.xlarge"},
+			Workers:      &profile.WorkersConfig{Replicas: 2, InstanceType: "g5.xlarge"},
+		},
+	}
+	ec2m := &mockEC2{endpoints: 1, vpcs: 1, eips: 0, instances: map[string]int{"m6i.2xlarge": 100}, vcpuByType: map[string]int32{"m6i.xlarge": 4}}
+	q := &mockQuotas{values: map[string]float64{
+		quotaServiceVPC + "/" + quotaCodeGatewayVPCEndpoints: 50,
+		quotaServiceVPC + "/" + quotaCodeVPCsPerRegion:       50,
+		quotaServiceEC2 + "/" + quotaCodeElasticIPs:          50,
+		quotaServiceEC2 + "/" + quotaCodeStandardVCPUs:       1, // would fail if checked
+	}}
+
+	if err := runQuotaChecks(context.Background(), "us-east-1", ec2m, q, prof); err != nil {
+		t.Fatalf("vCPU check should have been skipped for non-Standard family, got: %v", err)
+	}
+}
+
+func TestComputeVCPUNeed(t *testing.T) {
+	ec2m := &mockEC2{vcpuByType: map[string]int32{"m6i.xlarge": 4, "m6i.2xlarge": 8}}
+
+	need, ok := computeVCPUNeed(context.Background(), ec2m, standardProfile())
+	if !ok {
+		t.Fatal("expected vCPU need to be computable for Standard families")
+	}
+	// 4*3 (control plane) + 4 (bootstrap) + 8*3 (workers) = 40
+	if need != 40 {
+		t.Fatalf("expected need 40, got %d", need)
+	}
+
+	// Non-standard family -> not applicable.
+	nonStd := &profile.Profile{Compute: profile.ComputeConfig{
+		ControlPlane: &profile.ControlPlaneConfig{Replicas: 3, InstanceType: "g5.xlarge"},
+	}}
+	if _, ok := computeVCPUNeed(context.Background(), ec2m, nonStd); ok {
+		t.Fatal("expected vCPU need to be inapplicable for non-Standard family")
+	}
+}
+
+func TestEstimateAZCount(t *testing.T) {
+	if got := estimateAZCount(snoProfile()); got != 1 {
+		t.Fatalf("SNO: expected 1 AZ, got %d", got)
+	}
+	if got := estimateAZCount(standardProfile()); got != 3 {
+		t.Fatalf("standard: expected 3 AZs, got %d", got)
+	}
+}
+
+func TestIsStandardFamily(t *testing.T) {
+	cases := map[string]bool{
+		"m6i.xlarge":   true,
+		"c5.2xlarge":   true,
+		"t3.medium":    true,
+		"r6g.large":    true,
+		"g5.xlarge":    false, // GPU
+		"p4d.24xlarge": false, // GPU
+		"":             false,
+	}
+	for it, want := range cases {
+		if got := isStandardFamily(it); got != want {
+			t.Errorf("isStandardFamily(%q) = %v, want %v", it, got, want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Closes #100.

The existing AWS pre-flight (`CheckInstanceTypeAvailability`) validated only that requested instance types were offered across enough AZs — it never looked at account **service quotas**. So a create could pass pre-flight and then fail ~15 min into CAPI provisioning when a shared-account quota was exhausted. This is exactly what bit nadeem on 2026-08-19 (`VpcEndpointLimitExceeded` in `us-east-1`).

`CheckQuotas` now compares **applied quota vs. current usage vs. this cluster's need**, per region, for the four quotas every OpenShift IPI cluster consumes:

| Quota | Code | Need per cluster |
|-------|------|------------------|
| Gateway VPC endpoints per Region | `L-1B52E74A` | 1 (S3 gateway endpoint) |
| VPCs per Region | `L-F678F1CE` | 1 |
| Elastic IPs per Region | `L-0263D0A3` | 1 per AZ (NAT gateway) |
| Running On-Demand Standard vCPUs | `L-1216C47A` | control-plane + workers + 1 bootstrap |

## Design

- **Blocks only on a confirmed shortfall** — fails fast with a `PreflightCheckError` (no retry) listing every short quota + remediation steps.
- **Never a new source of outages** — any lookup that errors (missing IAM perm, throttling, unknown quota, empty value) is logged and **skipped**, falling back to the old behavior (create proceeds).
- **vCPU check is best-effort** — applies only to Standard-family types (A,C,D,H,I,M,R,T,Z), matching what `L-1216C47A` counts; non-Standard families (GPU `g5`/`p4d`, etc.) skip the vCPU check with a warning rather than compare against the wrong quota.

## IAM

No policy change needed — the worker role already grants `servicequotas:GetServiceQuota` and the `ec2:Describe*` calls used here (see `deploy/iam-policy-worker-full.json` Sid `ServiceQuotasRead` and `terraform/dev/openshift-provisioning-policy.json`).

## Tests

`internal/worker/quota_preflight_test.go` uses mocked `ec2QuotaAPI`/`quotasAPI` implementations covering: sufficient headroom passes, gateway-endpoint exhaustion blocks, Standard vCPU shortfall blocks, quota-lookup failure degrades gracefully, usage-lookup failure degrades gracefully, and non-Standard-family vCPU skip. `go test -race ./internal/worker/` passes.

## Docs

Added `docs/features/QUOTA_PREFLIGHT.md`.