### PR TITLE
Test coverage: CI reporting + security-critical package tests (#102)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,8 +45,33 @@ jobs:
       - name: go build
         run: go build ./cmd/...
 
-      - name: go test
-        run: go test -race ./...
+      - name: go test (race + coverage)
+        run: |
+          # Per-package coverage lines are printed by `go test` itself; the merged
+          # profile feeds the total. tee preserves them for the summary step.
+          go test -race -covermode=atomic -coverprofile=coverage.out ./... \
+            | tee test-output.txt
+
+      - name: Coverage summary
+        if: always()
+        run: |
+          if [ ! -f coverage.out ]; then
+            echo "No coverage profile produced (tests failed to compile?)."
+            exit 0
+          fi
+          total=$(go tool cover -func=coverage.out | tail -1 | awk '{print $NF}')
+          echo "Total coverage: ${total}"
+          {
+            echo "### Test coverage — total: ${total}"
+            echo ""
+            echo "Per-package (statements):"
+            echo '```'
+            # Package-level lines from the test run: "ok <pkg> ... coverage: X%"
+            # and "<pkg> [no test files]".
+            grep -E 'coverage:|no test files' test-output.txt \
+              | sed -E 's#github.com/tsanders-rh/ocpctl/##' || true
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
 
   # NOTE: golangci-lint is intentionally NOT wired up yet.
   # The last v1 release (v1.64.8) is built with go1.24 and refuses to run

--- a/internal/auth/apikey_test.go
+++ b/internal/auth/apikey_test.go
@@ -1,0 +1,66 @@
+package auth
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"strings"
+	"testing"
+)
+
+func TestGenerateAPIKey(t *testing.T) {
+	plain, prefix, hash, err := GenerateAPIKey()
+	if err != nil {
+		t.Fatalf("GenerateAPIKey: %v", err)
+	}
+
+	if !strings.HasPrefix(plain, APIKeyPrefix) {
+		t.Errorf("plain key %q missing prefix %q", plain, APIKeyPrefix)
+	}
+	if prefix != plain[:12]+"..." {
+		t.Errorf("display prefix = %q, want %q", prefix, plain[:12]+"...")
+	}
+
+	// Hash must be the hex sha256 of the plaintext key (so lookups match).
+	want := sha256.Sum256([]byte(plain))
+	if hash != hex.EncodeToString(want[:]) {
+		t.Errorf("hash = %q, want sha256(plain)", hash)
+	}
+	// sha256 hex is 64 chars.
+	if len(hash) != 64 {
+		t.Errorf("hash length = %d, want 64", len(hash))
+	}
+}
+
+func TestGenerateAPIKey_Unique(t *testing.T) {
+	seen := map[string]bool{}
+	for i := 0; i < 100; i++ {
+		plain, _, hash, err := GenerateAPIKey()
+		if err != nil {
+			t.Fatalf("GenerateAPIKey: %v", err)
+		}
+		if seen[plain] {
+			t.Fatalf("duplicate plaintext key: %q", plain)
+		}
+		if seen[hash] {
+			t.Fatalf("duplicate hash: %q", hash)
+		}
+		seen[plain] = true
+		seen[hash] = true
+	}
+}
+
+func TestIsAPIKey(t *testing.T) {
+	cases := map[string]bool{
+		"ocpctl_abc123":           true,
+		"ocpctl_":                 true,
+		"eyJhbGciOiJIUzI1NiIs...": false, // JWT
+		"":                        false,
+		"OCPCTL_upper":            false, // case-sensitive prefix
+		"prefix_ocpctl_x":         false,
+	}
+	for token, want := range cases {
+		if got := IsAPIKey(token); got != want {
+			t.Errorf("IsAPIKey(%q) = %v, want %v", token, got, want)
+		}
+	}
+}

--- a/internal/auth/jwt_test.go
+++ b/internal/auth/jwt_test.go
@@ -1,0 +1,158 @@
+package auth
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/tsanders-rh/ocpctl/pkg/types"
+)
+
+func testUser() *types.User {
+	return &types.User{
+		ID:           "user-123",
+		Email:        "alice@example.com",
+		Role:         types.RoleAdmin,
+		Teams:        []string{"platform"},
+		ManagedTeams: []string{"platform"},
+	}
+}
+
+func TestGenerateAndValidateAccessToken(t *testing.T) {
+	a := NewAuth("test-secret", time.Hour, 24*time.Hour)
+	u := testUser()
+
+	tok, err := a.GenerateAccessToken(u)
+	if err != nil {
+		t.Fatalf("generate: %v", err)
+	}
+
+	claims, err := a.ValidateAccessToken(tok)
+	if err != nil {
+		t.Fatalf("validate: %v", err)
+	}
+
+	if claims.UserID != u.ID {
+		t.Errorf("UserID = %q, want %q", claims.UserID, u.ID)
+	}
+	if claims.Email != u.Email {
+		t.Errorf("Email = %q, want %q", claims.Email, u.Email)
+	}
+	if claims.Role != string(u.Role) {
+		t.Errorf("Role = %q, want %q", claims.Role, u.Role)
+	}
+	if claims.Subject != u.ID {
+		t.Errorf("Subject = %q, want %q", claims.Subject, u.ID)
+	}
+	if claims.Issuer != "ocpctl" {
+		t.Errorf("Issuer = %q, want ocpctl", claims.Issuer)
+	}
+}
+
+func TestValidateAccessToken_WrongSecret(t *testing.T) {
+	issuer := NewAuth("secret-A", time.Hour, time.Hour)
+	verifier := NewAuth("secret-B", time.Hour, time.Hour)
+
+	tok, err := issuer.GenerateAccessToken(testUser())
+	if err != nil {
+		t.Fatalf("generate: %v", err)
+	}
+
+	if _, err := verifier.ValidateAccessToken(tok); err == nil {
+		t.Fatal("expected validation to fail with a different secret")
+	}
+}
+
+func TestValidateAccessToken_Expired(t *testing.T) {
+	// Negative TTL => token is already expired at issue time.
+	a := NewAuth("test-secret", -time.Minute, time.Hour)
+	tok, err := a.GenerateAccessToken(testUser())
+	if err != nil {
+		t.Fatalf("generate: %v", err)
+	}
+	_, err = a.ValidateAccessToken(tok)
+	if err == nil {
+		t.Fatal("expected expired token to fail validation")
+	}
+	if !strings.Contains(err.Error(), "parse token") {
+		t.Errorf("expected parse error, got %v", err)
+	}
+}
+
+func TestValidateAccessToken_Tampered(t *testing.T) {
+	a := NewAuth("test-secret", time.Hour, time.Hour)
+	tok, err := a.GenerateAccessToken(testUser())
+	if err != nil {
+		t.Fatalf("generate: %v", err)
+	}
+	// Flip the last character of the signature segment.
+	parts := strings.Split(tok, ".")
+	if len(parts) != 3 {
+		t.Fatalf("expected 3 JWT parts, got %d", len(parts))
+	}
+	sig := []byte(parts[2])
+	if sig[len(sig)-1] == 'A' {
+		sig[len(sig)-1] = 'B'
+	} else {
+		sig[len(sig)-1] = 'A'
+	}
+	tampered := parts[0] + "." + parts[1] + "." + string(sig)
+
+	if _, err := a.ValidateAccessToken(tampered); err == nil {
+		t.Fatal("expected tampered token to fail validation")
+	}
+}
+
+func TestValidateAccessToken_RejectsNoneAlg(t *testing.T) {
+	a := NewAuth("test-secret", time.Hour, time.Hour)
+
+	// Forge a token signed with the "none" algorithm.
+	claims := &Claims{UserID: "attacker", Role: string(types.RoleAdmin)}
+	tok := jwt.NewWithClaims(jwt.SigningMethodNone, claims)
+	signed, err := tok.SignedString(jwt.UnsafeAllowNoneSignatureType)
+	if err != nil {
+		t.Fatalf("sign none: %v", err)
+	}
+
+	if _, err := a.ValidateAccessToken(signed); err == nil {
+		t.Fatal("expected 'none'-signed token to be rejected")
+	}
+}
+
+func TestValidateAccessToken_Garbage(t *testing.T) {
+	a := NewAuth("test-secret", time.Hour, time.Hour)
+	for _, s := range []string{"", "not.a.token", "a.b", "....."} {
+		if _, err := a.ValidateAccessToken(s); err == nil {
+			t.Errorf("expected error for garbage token %q", s)
+		}
+	}
+}
+
+func TestGenerateRefreshToken_UniqueAndDecodable(t *testing.T) {
+	a := NewAuth("test-secret", time.Hour, time.Hour)
+	seen := map[string]bool{}
+	for i := 0; i < 100; i++ {
+		tok, err := a.GenerateRefreshToken()
+		if err != nil {
+			t.Fatalf("generate refresh: %v", err)
+		}
+		if tok == "" {
+			t.Fatal("empty refresh token")
+		}
+		if seen[tok] {
+			t.Fatalf("duplicate refresh token generated: %q", tok)
+		}
+		seen[tok] = true
+	}
+}
+
+func TestTTLGetters(t *testing.T) {
+	a := NewAuth("s", 15*time.Minute, 7*24*time.Hour)
+	if a.GetAccessTTL() != 15*time.Minute {
+		t.Errorf("access TTL = %v", a.GetAccessTTL())
+	}
+	if a.GetRefreshTTL() != 7*24*time.Hour {
+		t.Errorf("refresh TTL = %v", a.GetRefreshTTL())
+	}
+}

--- a/internal/auth/password_test.go
+++ b/internal/auth/password_test.go
@@ -1,0 +1,101 @@
+package auth
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestHashAndCheckPassword(t *testing.T) {
+	pw := "Sup3rSecret!"
+	hash, err := HashPassword(pw)
+	if err != nil {
+		t.Fatalf("hash: %v", err)
+	}
+	if hash == pw {
+		t.Fatal("hash must not equal plaintext")
+	}
+	if !strings.HasPrefix(hash, "$2") {
+		t.Errorf("expected bcrypt hash prefix, got %q", hash)
+	}
+
+	if err := CheckPassword(pw, hash); err != nil {
+		t.Errorf("correct password should verify: %v", err)
+	}
+	if err := CheckPassword("wrong", hash); err == nil {
+		t.Error("wrong password should not verify")
+	}
+}
+
+func TestHashPassword_Salted(t *testing.T) {
+	// bcrypt salts each hash, so the same password hashes differently each time.
+	h1, _ := HashPassword("samePassword1!")
+	h2, _ := HashPassword("samePassword1!")
+	if h1 == h2 {
+		t.Fatal("expected distinct hashes for the same password (salting)")
+	}
+}
+
+func TestCheckPassword_ErrorDoesNotLeakSecret(t *testing.T) {
+	hash, _ := HashPassword("Sup3rSecret!")
+	err := CheckPassword("attackerGuess123", hash)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if strings.Contains(err.Error(), "attackerGuess123") {
+		t.Errorf("error message leaked the attempted password: %v", err)
+	}
+}
+
+func TestValidatePasswordStrength(t *testing.T) {
+	tests := []struct {
+		name    string
+		pw      string
+		wantErr bool
+	}{
+		{"strong", "Str0ng!Pass", false},
+		{"too short", "Ab1!", true},
+		{"no upper", "str0ng!pass", true},
+		{"no lower", "STR0NG!PASS", true},
+		{"no number", "Strong!Pass", true},
+		{"no special", "Str0ngPass1", true},
+		{"common password", "Password123", true},
+		{"common with special", "Admin123!", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidatePasswordStrength(tt.pw)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("ValidatePasswordStrength(%q) err=%v, wantErr=%v", tt.pw, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestValidateEmail(t *testing.T) {
+	valid := []string{
+		"alice@example.com",
+		"bob.smith@sub.domain.co",
+		"a+tag@example.io",
+		"user_name@example-host.com",
+	}
+	for _, e := range valid {
+		if err := ValidateEmail(e); err != nil {
+			t.Errorf("expected %q to be valid: %v", e, err)
+		}
+	}
+
+	invalid := []string{
+		"",
+		"no-at-sign",
+		"@example.com",
+		"user@",
+		"user@nodot",
+		"user@domain.c", // TLD too short
+		"user name@example.com",
+	}
+	for _, e := range invalid {
+		if err := ValidateEmail(e); err == nil {
+			t.Errorf("expected %q to be invalid", e)
+		}
+	}
+}

--- a/internal/secrets/manager.go
+++ b/internal/secrets/manager.go
@@ -14,9 +14,15 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/secretsmanager"
 )
 
+// secretsAPI is the subset of the AWS Secrets Manager client used by Manager.
+// It is satisfied by *secretsmanager.Client and mocked in tests.
+type secretsAPI interface {
+	GetSecretValue(context.Context, *secretsmanager.GetSecretValueInput, ...func(*secretsmanager.Options)) (*secretsmanager.GetSecretValueOutput, error)
+}
+
 // Manager handles retrieval of secrets from AWS Secrets Manager with caching
 type Manager struct {
-	client *secretsmanager.Client
+	client secretsAPI
 	cache  map[string]*cachedSecret
 	mu     sync.RWMutex
 	ttl    time.Duration

--- a/internal/secrets/manager_test.go
+++ b/internal/secrets/manager_test.go
@@ -1,0 +1,194 @@
+package secrets
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/secretsmanager"
+)
+
+// mockSecrets is a mock secretsAPI. It counts calls so tests can assert on
+// caching (i.e. that the AWS API is NOT hit on a cache hit).
+type mockSecrets struct {
+	value *string // SecretString to return (nil => binary secret)
+	err   error
+	calls int
+}
+
+func (m *mockSecrets) GetSecretValue(_ context.Context, _ *secretsmanager.GetSecretValueInput, _ ...func(*secretsmanager.Options)) (*secretsmanager.GetSecretValueOutput, error) {
+	m.calls++
+	if m.err != nil {
+		return nil, m.err
+	}
+	return &secretsmanager.GetSecretValueOutput{SecretString: m.value}, nil
+}
+
+func newTestManager(client secretsAPI) *Manager {
+	return &Manager{
+		client: client,
+		cache:  make(map[string]*cachedSecret),
+		ttl:    5 * time.Minute,
+	}
+}
+
+func TestGetSecret_Success(t *testing.T) {
+	m := newTestManager(&mockSecrets{value: aws.String("s3cr3t")})
+	got, err := m.GetSecret(context.Background(), "db/password")
+	if err != nil {
+		t.Fatalf("GetSecret: %v", err)
+	}
+	if got != "s3cr3t" {
+		t.Fatalf("got %q, want s3cr3t", got)
+	}
+}
+
+func TestGetSecret_CachesValue(t *testing.T) {
+	mock := &mockSecrets{value: aws.String("cached-value")}
+	m := newTestManager(mock)
+
+	for i := 0; i < 3; i++ {
+		v, err := m.GetSecret(context.Background(), "key")
+		if err != nil || v != "cached-value" {
+			t.Fatalf("call %d: v=%q err=%v", i, v, err)
+		}
+	}
+	if mock.calls != 1 {
+		t.Fatalf("expected exactly 1 AWS call (rest served from cache), got %d", mock.calls)
+	}
+}
+
+func TestGetSecret_ExpiredCacheRefetches(t *testing.T) {
+	mock := &mockSecrets{value: aws.String("v1")}
+	m := newTestManager(mock)
+
+	// Seed an already-expired cache entry.
+	m.cache["key"] = &cachedSecret{value: "stale", expiresAt: time.Now().Add(-time.Minute)}
+
+	v, err := m.GetSecret(context.Background(), "key")
+	if err != nil {
+		t.Fatalf("GetSecret: %v", err)
+	}
+	if v != "v1" {
+		t.Fatalf("expected refetch to return v1, got %q", v)
+	}
+	if mock.calls != 1 {
+		t.Fatalf("expected 1 AWS call on expired cache, got %d", mock.calls)
+	}
+}
+
+func TestGetSecret_BinarySecretError(t *testing.T) {
+	m := newTestManager(&mockSecrets{value: nil}) // nil SecretString => binary
+	_, err := m.GetSecret(context.Background(), "binkey")
+	if err == nil {
+		t.Fatal("expected error for binary secret")
+	}
+	if !strings.Contains(err.Error(), "binary") {
+		t.Errorf("expected binary error, got %v", err)
+	}
+}
+
+func TestGetSecret_APIError_NoSecretLeak(t *testing.T) {
+	m := newTestManager(&mockSecrets{err: errors.New("AccessDeniedException")})
+	_, err := m.GetSecret(context.Background(), "db/password")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	// Error should name the secret ID but never contain a fetched value
+	// (there is none here) — sanity check the wrapping mentions the key.
+	if !strings.Contains(err.Error(), "db/password") {
+		t.Errorf("expected error to reference secret name, got %v", err)
+	}
+}
+
+func TestGetJSONSecret(t *testing.T) {
+	m := newTestManager(&mockSecrets{value: aws.String(`{"user":"admin","port":5432}`)})
+	var target struct {
+		User string `json:"user"`
+		Port int    `json:"port"`
+	}
+	if err := m.GetJSONSecret(context.Background(), "db/conn", &target); err != nil {
+		t.Fatalf("GetJSONSecret: %v", err)
+	}
+	if target.User != "admin" || target.Port != 5432 {
+		t.Fatalf("unexpected parse result: %+v", target)
+	}
+}
+
+func TestGetJSONSecret_InvalidJSON(t *testing.T) {
+	m := newTestManager(&mockSecrets{value: aws.String("not json")})
+	var target map[string]any
+	if err := m.GetJSONSecret(context.Background(), "db/conn", &target); err == nil {
+		t.Fatal("expected JSON parse error")
+	}
+}
+
+func TestInvalidateCache(t *testing.T) {
+	mock := &mockSecrets{value: aws.String("v")}
+	m := newTestManager(mock)
+
+	if _, err := m.GetSecret(context.Background(), "key"); err != nil {
+		t.Fatalf("prime cache: %v", err)
+	}
+	m.InvalidateCache("key")
+	if _, err := m.GetSecret(context.Background(), "key"); err != nil {
+		t.Fatalf("refetch: %v", err)
+	}
+	if mock.calls != 2 {
+		t.Fatalf("expected 2 AWS calls after invalidation, got %d", mock.calls)
+	}
+}
+
+func TestInvalidateAllCache(t *testing.T) {
+	mock := &mockSecrets{value: aws.String("v")}
+	m := newTestManager(mock)
+	if _, err := m.GetSecret(context.Background(), "a"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := m.GetSecret(context.Background(), "b"); err != nil {
+		t.Fatal(err)
+	}
+	m.InvalidateAllCache()
+	if len(m.cache) != 0 {
+		t.Fatalf("expected empty cache, got %d entries", len(m.cache))
+	}
+}
+
+func TestGetSecretWithFallback_EnvVar(t *testing.T) {
+	// secretName empty => skip Secrets Manager, read from env (dev path).
+	m := newTestManager(&mockSecrets{err: errors.New("should not be called")})
+	t.Setenv("ENVIRONMENT", "development")
+	t.Setenv("MY_TOKEN", "from-env")
+
+	v, err := m.GetSecretWithFallback(context.Background(), "", "MY_TOKEN", true)
+	if err != nil {
+		t.Fatalf("fallback: %v", err)
+	}
+	if v != "from-env" {
+		t.Fatalf("got %q, want from-env", v)
+	}
+}
+
+func TestGetSecretWithFallback_RequiredMissing(t *testing.T) {
+	m := newTestManager(&mockSecrets{})
+	t.Setenv("ENVIRONMENT", "development")
+	t.Setenv("MISSING_TOKEN", "")
+
+	_, err := m.GetSecretWithFallback(context.Background(), "", "MISSING_TOKEN", true)
+	if err == nil {
+		t.Fatal("expected error when required env var is missing")
+	}
+}
+
+func TestGetSecretWithFallback_ProductionRequiresName(t *testing.T) {
+	m := newTestManager(&mockSecrets{})
+	t.Setenv("ENVIRONMENT", "production")
+
+	_, err := m.GetSecretWithFallback(context.Background(), "", "SOME_TOKEN", true)
+	if err == nil {
+		t.Fatal("expected error: production requires a secret name")
+	}
+}

--- a/internal/validation/postconfig_test.go
+++ b/internal/validation/postconfig_test.go
@@ -1,0 +1,298 @@
+package validation
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/tsanders-rh/ocpctl/pkg/types"
+)
+
+// hasFieldError reports whether errs contains a PostConfigValidationError whose
+// Field matches (or is prefixed by) want.
+func hasFieldError(errs []error, want string) bool {
+	for _, e := range errs {
+		if ve, ok := e.(*PostConfigValidationError); ok {
+			if ve.Field == want || strings.HasPrefix(ve.Field, want) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func TestValidateCustomPostConfig_Nil(t *testing.T) {
+	if errs := ValidateCustomPostConfig(nil); errs != nil {
+		t.Fatalf("expected nil for nil config, got %v", errs)
+	}
+}
+
+func TestValidateCustomPostConfig_ValidMinimal(t *testing.T) {
+	cfg := &types.CustomPostConfig{
+		Operators: []types.CustomOperatorConfig{
+			{Name: "cnv", Namespace: "openshift-cnv", Channel: "stable"},
+		},
+		Scripts: []types.CustomScriptConfig{
+			{Name: "hello", Content: "echo hi", Timeout: "10m", Env: map[string]string{"FOO_BAR": "baz"}},
+		},
+		Manifests: []types.CustomManifestConfig{
+			{Name: "ns", Content: "kind: Namespace"},
+		},
+		HelmCharts: []types.CustomHelmChartConfig{
+			{Name: "app", Repo: "https://charts.example.com", Chart: "app"},
+		},
+	}
+	if errs := ValidateCustomPostConfig(cfg); len(errs) != 0 {
+		t.Fatalf("expected no errors for valid config, got %v", errs)
+	}
+}
+
+func TestValidateCustomPostConfig_ResourceLimits(t *testing.T) {
+	cfg := &types.CustomPostConfig{}
+	for i := 0; i <= MaxScriptsPerCluster; i++ {
+		cfg.Scripts = append(cfg.Scripts, types.CustomScriptConfig{Name: "s", Content: "x"})
+	}
+	for i := 0; i <= MaxOperatorsPerCluster; i++ {
+		cfg.Operators = append(cfg.Operators, types.CustomOperatorConfig{Name: "o", Namespace: "n", Channel: "c"})
+	}
+	for i := 0; i <= MaxManifestsPerCluster; i++ {
+		cfg.Manifests = append(cfg.Manifests, types.CustomManifestConfig{Name: "m", Content: "x"})
+	}
+	for i := 0; i <= MaxHelmChartsPerCluster; i++ {
+		cfg.HelmCharts = append(cfg.HelmCharts, types.CustomHelmChartConfig{Name: "h", Repo: "https://x.io", Chart: "c"})
+	}
+
+	errs := ValidateCustomPostConfig(cfg)
+	for _, field := range []string{"scripts", "operators", "manifests", "helmCharts"} {
+		if !hasFieldError(errs, field) {
+			t.Errorf("expected a resource-limit error for %q, got %v", field, errs)
+		}
+	}
+}
+
+func TestValidateOperator(t *testing.T) {
+	tests := []struct {
+		name    string
+		op      types.CustomOperatorConfig
+		wantErr []string // field suffixes expected
+	}{
+		{"valid", types.CustomOperatorConfig{Name: "n", Namespace: "ns", Channel: "ch"}, nil},
+		{"missing name", types.CustomOperatorConfig{Namespace: "ns", Channel: "ch"}, []string{"operators[0].name"}},
+		{"missing namespace", types.CustomOperatorConfig{Name: "n", Channel: "ch"}, []string{"operators[0].namespace"}},
+		{"missing channel", types.CustomOperatorConfig{Name: "n", Namespace: "ns"}, []string{"operators[0].channel"}},
+		{"all missing", types.CustomOperatorConfig{}, []string{"operators[0].name", "operators[0].namespace", "operators[0].channel"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			errs := validateOperator(tt.op, 0)
+			if len(tt.wantErr) == 0 && len(errs) != 0 {
+				t.Fatalf("expected no errors, got %v", errs)
+			}
+			for _, want := range tt.wantErr {
+				if !hasFieldError(errs, want) {
+					t.Errorf("expected error for %q, got %v", want, errs)
+				}
+			}
+		})
+	}
+}
+
+func TestValidateScript_SourceMutualExclusion(t *testing.T) {
+	tests := []struct {
+		name      string
+		script    types.CustomScriptConfig
+		wantError bool
+	}{
+		{"content only", types.CustomScriptConfig{Name: "s", Content: "x"}, false},
+		{"url only", types.CustomScriptConfig{Name: "s", URL: "https://e.io/s.sh"}, false},
+		{"path only", types.CustomScriptConfig{Name: "s", Path: "s.sh"}, false},
+		{"none", types.CustomScriptConfig{Name: "s"}, true},
+		{"content+url", types.CustomScriptConfig{Name: "s", Content: "x", URL: "https://e.io/s.sh"}, true},
+		{"all three", types.CustomScriptConfig{Name: "s", Content: "x", URL: "https://e.io/s.sh", Path: "s.sh"}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			errs := validateScript(tt.script, 0)
+			got := hasFieldError(errs, "scripts[0]")
+			if got != tt.wantError {
+				t.Fatalf("wantError=%v, got errs=%v", tt.wantError, errs)
+			}
+		})
+	}
+}
+
+func TestValidateScript_ContentSize(t *testing.T) {
+	big := strings.Repeat("a", MaxScriptSize+1)
+	errs := validateScript(types.CustomScriptConfig{Name: "s", Content: big}, 0)
+	if !hasFieldError(errs, "scripts[0].content") {
+		t.Fatalf("expected content-size error, got %v", errs)
+	}
+}
+
+func TestValidateScript_Timeout(t *testing.T) {
+	tests := []struct {
+		name    string
+		timeout string
+		wantErr bool
+	}{
+		{"valid", "10m", false},
+		{"unparseable", "not-a-duration", true},
+		{"over max", "7h", true},
+		{"zero", "0s", true},
+		{"negative", "-5m", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			errs := validateScript(types.CustomScriptConfig{Name: "s", Content: "x", Timeout: tt.timeout}, 0)
+			got := hasFieldError(errs, "scripts[0].timeout")
+			if got != tt.wantErr {
+				t.Fatalf("wantErr=%v, got errs=%v", tt.wantErr, errs)
+			}
+		})
+	}
+}
+
+func TestValidateScript_EnvVars(t *testing.T) {
+	tests := []struct {
+		name    string
+		env     map[string]string
+		wantErr bool
+	}{
+		{"valid", map[string]string{"MY_VAR": "value"}, false},
+		{"invalid name", map[string]string{"1BAD": "value"}, true},
+		{"dangerous LD_PRELOAD", map[string]string{"LD_PRELOAD": "/tmp/evil.so"}, true},
+		{"dangerous path lowercase", map[string]string{"path": "/evil"}, true},
+		{"value too large", map[string]string{"OK": strings.Repeat("x", 4097)}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			errs := validateScript(types.CustomScriptConfig{Name: "s", Content: "x", Env: tt.env}, 0)
+			got := hasFieldError(errs, "scripts[0].env")
+			if got != tt.wantErr {
+				t.Fatalf("wantErr=%v, got errs=%v", tt.wantErr, errs)
+			}
+		})
+	}
+}
+
+func TestValidateManifest(t *testing.T) {
+	tests := []struct {
+		name      string
+		manifest  types.CustomManifestConfig
+		wantField string // "" means no error expected
+	}{
+		{"valid content", types.CustomManifestConfig{Name: "m", Content: "x"}, ""},
+		{"valid url", types.CustomManifestConfig{Name: "m", URL: "https://e.io/m.yaml"}, ""},
+		{"missing name", types.CustomManifestConfig{Content: "x"}, "manifests[0].name"},
+		{"neither content nor url", types.CustomManifestConfig{Name: "m"}, "manifests[0]"},
+		{"both content and url", types.CustomManifestConfig{Name: "m", Content: "x", URL: "https://e.io/m.yaml"}, "manifests[0]"},
+		{"bad url", types.CustomManifestConfig{Name: "m", URL: "ftp://e.io/m.yaml"}, "manifests[0].url"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			errs := validateManifest(tt.manifest, 0)
+			if tt.wantField == "" {
+				if len(errs) != 0 {
+					t.Fatalf("expected no errors, got %v", errs)
+				}
+				return
+			}
+			if !hasFieldError(errs, tt.wantField) {
+				t.Fatalf("expected error for %q, got %v", tt.wantField, errs)
+			}
+		})
+	}
+}
+
+func TestValidateManifest_ContentSize(t *testing.T) {
+	big := strings.Repeat("a", MaxManifestSize+1)
+	errs := validateManifest(types.CustomManifestConfig{Name: "m", Content: big}, 0)
+	if !hasFieldError(errs, "manifests[0].content") {
+		t.Fatalf("expected content-size error, got %v", errs)
+	}
+}
+
+func TestValidateHelmChart(t *testing.T) {
+	tests := []struct {
+		name      string
+		chart     types.CustomHelmChartConfig
+		wantField string
+	}{
+		{"valid", types.CustomHelmChartConfig{Name: "h", Repo: "https://charts.io", Chart: "c"}, ""},
+		{"missing name", types.CustomHelmChartConfig{Repo: "https://charts.io", Chart: "c"}, "helmCharts[0].name"},
+		{"missing repo", types.CustomHelmChartConfig{Name: "h", Chart: "c"}, "helmCharts[0].repo"},
+		{"bad repo url", types.CustomHelmChartConfig{Name: "h", Repo: "not a url", Chart: "c"}, "helmCharts[0].repo"},
+		{"missing chart", types.CustomHelmChartConfig{Name: "h", Repo: "https://charts.io"}, "helmCharts[0].chart"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			errs := validateHelmChart(tt.chart, 0)
+			if tt.wantField == "" {
+				if len(errs) != 0 {
+					t.Fatalf("expected no errors, got %v", errs)
+				}
+				return
+			}
+			if !hasFieldError(errs, tt.wantField) {
+				t.Fatalf("expected error for %q, got %v", tt.wantField, errs)
+			}
+		})
+	}
+}
+
+func TestValidateURL(t *testing.T) {
+	tests := []struct {
+		url     string
+		wantErr bool
+	}{
+		{"https://example.com/x", false},
+		{"http://example.com", false},
+		{"ftp://example.com", true},  // wrong scheme
+		{"file:///etc/passwd", true}, // wrong scheme
+		{"https://", true},           // no host
+		{"://missing-scheme", true},  // parse/scheme failure
+		{"", true},                   // empty
+	}
+	for _, tt := range tests {
+		t.Run(tt.url, func(t *testing.T) {
+			err := validateURL(tt.url)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("validateURL(%q) err=%v, wantErr=%v", tt.url, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestIsValidEnvVarName(t *testing.T) {
+	cases := map[string]bool{
+		"FOO":       true,
+		"_foo":      true,
+		"foo_BAR_9": true,
+		"a":         true,
+		"":          false,
+		"1FOO":      false,
+		"FOO-BAR":   false,
+		"FOO BAR":   false,
+		"FOO.BAR":   false,
+	}
+	for name, want := range cases {
+		if got := isValidEnvVarName(name); got != want {
+			t.Errorf("isValidEnvVarName(%q) = %v, want %v", name, got, want)
+		}
+	}
+}
+
+func TestIsDangerousEnvVar(t *testing.T) {
+	// Case-insensitive blocklist.
+	dangerous := []string{"LD_PRELOAD", "ld_preload", "PATH", "path", "BASH_ENV", "IFS", "PYTHONPATH"}
+	for _, name := range dangerous {
+		if !isDangerousEnvVar(name) {
+			t.Errorf("expected %q to be flagged dangerous", name)
+		}
+	}
+	safe := []string{"MY_VAR", "HOME_DIR", "APP_CONFIG", "FOO"}
+	for _, name := range safe {
+		if isDangerousEnvVar(name) {
+			t.Errorf("expected %q to be safe", name)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

First slice of #102. Per the agreed slicing (quick security wins first), this adds **CI coverage reporting** plus unit tests for the pure-logic **security-critical** packages. No production-code refactor beyond one minimal, behavior-preserving interface extraction in `secrets`.

## CI coverage reporting

`go test` now runs with `-covermode=atomic -coverprofile=coverage.out` and a **Coverage summary** step writes total + per-package coverage to the GitHub step summary — so the gap is measurable and can't silently regrow (an acceptance criterion of #102).

## Tests added

| Package | Coverage | What's covered |
|---------|----------|----------------|
| `internal/validation` | **94.2%** | resource limits; script/manifest/helm validation; content-source mutual exclusion; timeout bounds; URL scheme/host checks; env-var name rules; **dangerous env-var blocklist** (LD_PRELOAD/PATH/BASH_ENV/…) |
| `internal/auth` | 21.1%* | JWT issue/verify, wrong-secret, expiry, tampering, **`none`-alg rejection**, garbage input; bcrypt hash/check/salting + no-secret-leak-in-errors; password-strength rules; email validation; API-key gen/hash/uniqueness + `IsAPIKey` |
| `internal/secrets` | **69.5%** | GetSecret success / caching / expiry-refetch; binary-secret error; API-error wrapping (no value leak); JSON parse ok/fail; cache invalidation; env-var fallback paths |

\* Auth's *package-level* number is modest because `iam.go` (STS) and `middleware.go` (echo) remain untested — the functions **in scope for this PR** (jwt, password, apikey gen) are well covered. That residual gap is now visible in the coverage summary, which is the point.

## Minimal refactor

`secrets`: extracted a one-method `secretsAPI` interface (satisfied by `*secretsmanager.Client`) so `GetSecret` is testable without hitting AWS. `NewManager` signature and behavior unchanged.

## Follow-ups (tracked under #102)

- **PR2** — `internal/aws/cleanup` + `internal/janitor` (the destructive-teardown packages; the #101 blast radius). These need interface extraction to mock EC2/ELB, so they're their own PR.
- **PR3** — `internal/api/middleware`, `poolscheduler`, `s3`, `k8s`.

Refs #102.