### PR TITLE
Make janitor safety/cleanup logic unit-testable via store interfaces

### DIFF
--- a/internal/janitor/janitor.go
+++ b/internal/janitor/janitor.go
@@ -46,7 +46,7 @@ func DefaultConfig() *Config {
 // Janitor performs periodic cleanup tasks
 type Janitor struct {
 	config           *Config
-	store            *store.Store
+	stores           janitorStores
 	workDir          string
 	running          bool
 	ctx              context.Context
@@ -69,7 +69,7 @@ func NewJanitor(config *Config, st *store.Store, workDir string) *Janitor {
 
 	return &Janitor{
 		config:           config,
-		store:            st,
+		stores:           storesFromStore(st),
 		workDir:          workDir,
 		running:          false,
 		metricsPublisher: metricsPublisher,
@@ -201,7 +201,7 @@ func (j *Janitor) run() {
 
 // cleanupExpiredClusters checks for clusters past their TTL and creates destroy jobs
 func (j *Janitor) cleanupExpiredClusters(ctx context.Context) error {
-	expired, err := j.store.Clusters.GetExpiredClusters(ctx)
+	expired, err := j.stores.clusters.GetExpiredClusters(ctx)
 	if err != nil {
 		return err
 	}
@@ -220,7 +220,7 @@ func (j *Janitor) cleanupExpiredClusters(ctx context.Context) error {
 		}
 
 		// Check if destroy job already exists
-		jobs, err := j.store.Jobs.ListByClusterID(ctx, cluster.ID)
+		jobs, err := j.stores.jobs.ListByClusterID(ctx, cluster.ID)
 		if err != nil {
 			log.Printf("Failed to list jobs for cluster %s: %v", cluster.ID, err)
 			continue
@@ -255,13 +255,13 @@ func (j *Janitor) cleanupExpiredClusters(ctx context.Context) error {
 			UpdatedAt:   time.Now(),
 		}
 
-		if err := j.store.Jobs.Create(ctx, nil, job); err != nil {
+		if err := j.stores.jobs.Create(ctx, nil, job); err != nil {
 			log.Printf("Failed to create destroy job for cluster %s: %v", cluster.Name, err)
 			continue
 		}
 
 		// Update cluster status to DESTROYING
-		if err := j.store.Clusters.UpdateStatus(ctx, nil, cluster.ID, types.ClusterStatusDestroying); err != nil {
+		if err := j.stores.clusters.UpdateStatus(ctx, nil, cluster.ID, types.ClusterStatusDestroying); err != nil {
 			log.Printf("Failed to update cluster %s status: %v", cluster.Name, err)
 		}
 
@@ -273,7 +273,7 @@ func (j *Janitor) cleanupExpiredClusters(ctx context.Context) error {
 
 // cleanupStuckJobs detects jobs stuck in RUNNING status
 func (j *Janitor) cleanupStuckJobs(ctx context.Context) error {
-	stuck, err := j.store.Jobs.GetStuckJobs(ctx, j.config.StuckJobThreshold)
+	stuck, err := j.stores.jobs.GetStuckJobs(ctx, j.config.StuckJobThreshold)
 	if err != nil {
 		return err
 	}
@@ -289,7 +289,7 @@ func (j *Janitor) cleanupStuckJobs(ctx context.Context) error {
 			job.ID, job.JobType, job.ClusterID, job.StartedAt, job.Attempt, job.MaxAttempts)
 
 		// Release any locks held by this job first
-		if err := j.store.JobLocks.Release(ctx, job.ClusterID, job.ID); err != nil {
+		if err := j.stores.jobLocks.Release(ctx, job.ClusterID, job.ID); err != nil {
 			log.Printf("Failed to release lock for cluster %s: %v", job.ClusterID, err)
 		}
 
@@ -302,7 +302,7 @@ func (j *Janitor) cleanupStuckJobs(ctx context.Context) error {
 			errorCode := "WORKER_CRASHED"
 			errorMessage := "Job exceeded maximum runtime (likely worker crash), resetting for retry"
 
-			if err := j.store.Jobs.MarkFailedForRetry(ctx, job.ID, errorCode, errorMessage); err != nil {
+			if err := j.stores.jobs.MarkFailedForRetry(ctx, job.ID, errorCode, errorMessage); err != nil {
 				log.Printf("Failed to reset job %s for retry: %v", job.ID, err)
 				continue
 			}
@@ -314,7 +314,7 @@ func (j *Janitor) cleanupStuckJobs(ctx context.Context) error {
 			errorCode := "STUCK_JOB_TIMEOUT"
 			errorMessage := "Job exceeded maximum runtime and exhausted all retry attempts"
 
-			if err := j.store.Jobs.MarkFailed(ctx, job.ID, errorCode, errorMessage); err != nil {
+			if err := j.stores.jobs.MarkFailed(ctx, job.ID, errorCode, errorMessage); err != nil {
 				log.Printf("Failed to mark job %s as failed: %v", job.ID, err)
 				continue
 			}
@@ -325,12 +325,12 @@ func (j *Janitor) cleanupStuckJobs(ctx context.Context) error {
 				// The destroy job timed out or got stuck, so we don't know if AWS resources were deleted
 				// An admin can manually verify and mark as DESTROYED, or reconciliation can detect drift
 				log.Printf("Marking cluster %s as DESTROY_FAILED (stuck destroy job - verification required)", job.ClusterID)
-				if err := j.store.Clusters.UpdateStatus(ctx, nil, job.ClusterID, types.ClusterStatusDestroyFailed); err != nil {
+				if err := j.stores.clusters.UpdateStatus(ctx, nil, job.ClusterID, types.ClusterStatusDestroyFailed); err != nil {
 					log.Printf("Failed to mark cluster %s as destroy failed: %v", job.ClusterID, err)
 				}
 			} else {
 				// For other job types, mark cluster as FAILED
-				if err := j.store.Clusters.UpdateStatus(ctx, nil, job.ClusterID, types.ClusterStatusFailed); err != nil {
+				if err := j.stores.clusters.UpdateStatus(ctx, nil, job.ClusterID, types.ClusterStatusFailed); err != nil {
 					log.Printf("Failed to update cluster %s status to FAILED: %v", job.ClusterID, err)
 				}
 			}
@@ -347,7 +347,7 @@ func (j *Janitor) cleanupStuckJobs(ctx context.Context) error {
 // crashed after marking a job as FAILED but before completing the cleanup process.
 func (j *Janitor) cleanupIncompleteFailedJobs(ctx context.Context) error {
 	// Get all incomplete failed jobs
-	incompleteJobs, err := j.store.Jobs.GetIncompleteFailedJobs(ctx)
+	incompleteJobs, err := j.stores.jobs.GetIncompleteFailedJobs(ctx)
 	if err != nil {
 		return fmt.Errorf("get incomplete failed jobs: %w", err)
 	}
@@ -363,13 +363,13 @@ func (j *Janitor) cleanupIncompleteFailedJobs(ctx context.Context) error {
 			job.ID, job.JobType, job.ClusterID, job.StartedAt)
 
 		// Release any locks held by this job
-		if err := j.store.JobLocks.Release(ctx, job.ClusterID, job.ID); err != nil {
+		if err := j.stores.jobLocks.Release(ctx, job.ClusterID, job.ID); err != nil {
 			log.Printf("Warning: Failed to release lock for cluster %s: %v", job.ClusterID, err)
 			// Continue even if lock release fails - we still want to set ended_at
 		}
 
 		// Complete the cleanup by setting ended_at
-		if err := j.store.Jobs.CompleteFailedJobCleanup(ctx, job.ID); err != nil {
+		if err := j.stores.jobs.CompleteFailedJobCleanup(ctx, job.ID); err != nil {
 			log.Printf("Failed to complete cleanup for job %s: %v", job.ID, err)
 			continue
 		}
@@ -387,7 +387,7 @@ func (j *Janitor) detectStuckLocks(ctx context.Context) error {
 	// Stuck threshold: 96 minutes (80% of 120 minutes)
 	stuckThreshold := 96 * time.Minute
 
-	locks, err := j.store.JobLocks.GetStuckLocks(ctx, stuckThreshold)
+	locks, err := j.stores.jobLocks.GetStuckLocks(ctx, stuckThreshold)
 	if err != nil {
 		return err
 	}
@@ -407,13 +407,13 @@ func (j *Janitor) detectStuckLocks(ctx context.Context) error {
 			lock.ClusterID, lock.JobID, lock.LockedBy, lockAge, timeUntilExpiry)
 
 		// Get cluster and job details for more context
-		cluster, clusterErr := j.store.Clusters.GetByID(ctx, lock.ClusterID)
+		cluster, clusterErr := j.stores.clusters.GetByID(ctx, lock.ClusterID)
 		if clusterErr == nil {
 			log.Printf("  Cluster: name=%s, status=%s, platform=%s, profile=%s",
 				cluster.Name, cluster.Status, cluster.Platform, cluster.Profile)
 		}
 
-		job, jobErr := j.store.Jobs.GetByID(ctx, lock.JobID)
+		job, jobErr := j.stores.jobs.GetByID(ctx, lock.JobID)
 		if jobErr == nil {
 			log.Printf("  Job: type=%s, status=%s, attempt=%d/%d, started=%v",
 				job.JobType, job.Status, job.Attempt, job.MaxAttempts, job.StartedAt)
@@ -465,7 +465,7 @@ func (j *Janitor) detectStuckLocks(ctx context.Context) error {
 
 // cleanupExpiredLocks removes expired job locks
 func (j *Janitor) cleanupExpiredLocks(ctx context.Context) error {
-	count, err := j.store.JobLocks.CleanupExpired(ctx)
+	count, err := j.stores.jobLocks.CleanupExpired(ctx)
 	if err != nil {
 		return err
 	}
@@ -486,7 +486,7 @@ func (j *Janitor) cleanupExpiredLocks(ctx context.Context) error {
 
 // cleanupExpiredKeys removes expired idempotency keys
 func (j *Janitor) cleanupExpiredKeys(ctx context.Context) error {
-	count, err := j.store.Idempotency.CleanupExpired(ctx)
+	count, err := j.stores.idempotency.CleanupExpired(ctx)
 	if err != nil {
 		return err
 	}
@@ -503,7 +503,7 @@ func (j *Janitor) cleanupDestroyedClusters(ctx context.Context) error {
 	// Calculate cutoff time based on retention days
 	cutoff := time.Now().AddDate(0, 0, -j.config.DestroyedClusterRetentionDays)
 
-	count, err := j.store.Clusters.DeleteDestroyedClusters(ctx, cutoff)
+	count, err := j.stores.clusters.DeleteDestroyedClusters(ctx, cutoff)
 	if err != nil {
 		return err
 	}
@@ -525,7 +525,7 @@ func (j *Janitor) cleanupFailedClusterDirs(ctx context.Context) error {
 		Offset: 0,
 	}
 
-	clusters, _, err := j.store.Clusters.List(ctx, filters)
+	clusters, _, err := j.stores.clusters.List(ctx, filters)
 	if err != nil {
 		return err
 	}
@@ -574,7 +574,7 @@ func (j *Janitor) cleanupOrphanedDirs(ctx context.Context) error {
 	validClusterIDs := make(map[string]bool)
 
 	// Use streaming iterator with 1000 clusters per batch
-	clustersCh, errCh := j.store.Clusters.ListAllStreaming(ctx, 1000)
+	clustersCh, errCh := j.stores.clusters.ListAllStreaming(ctx, 1000)
 
 	// Process batches as they arrive
 	for {
@@ -647,7 +647,7 @@ ProcessDirectories:
 // enforceWorkHours enforces work hours by hibernating/resuming clusters
 func (j *Janitor) enforceWorkHours(ctx context.Context) error {
 	// Get clusters with work hours enabled
-	clusters, err := j.store.Clusters.GetClustersForWorkHoursEnforcement(ctx)
+	clusters, err := j.stores.clusters.GetClustersForWorkHoursEnforcement(ctx)
 	if err != nil {
 		return err
 	}
@@ -661,7 +661,7 @@ func (j *Janitor) enforceWorkHours(ctx context.Context) error {
 	actionsCount := 0
 	for _, cluster := range clusters {
 		// Get the user to access their timezone and default work hours
-		user, err := j.store.Users.GetByID(ctx, cluster.OwnerID)
+		user, err := j.stores.users.GetByID(ctx, cluster.OwnerID)
 		if err != nil {
 			log.Printf("Failed to get user for cluster %s: %v", cluster.Name, err)
 			continue
@@ -742,7 +742,7 @@ func (j *Janitor) enforceWorkHours(ctx context.Context) error {
 				(*cluster.PostDeployStatus == "pending" || *cluster.PostDeployStatus == "in_progress") {
 				log.Printf("[Work Hours Action] SKIPPING HIBERNATION for %s: post-deployment %s", cluster.Name, *cluster.PostDeployStatus)
 				// Update check timestamp so we don't spam logs
-				if err := j.store.Clusters.UpdateLastWorkHoursCheck(ctx, cluster.ID); err != nil {
+				if err := j.stores.clusters.UpdateLastWorkHoursCheck(ctx, cluster.ID); err != nil {
 					log.Printf("Failed to update last_work_hours_check for cluster %s: %v", cluster.Name, err)
 				}
 				continue
@@ -759,7 +759,7 @@ func (j *Janitor) enforceWorkHours(ctx context.Context) error {
 		} else {
 			// No action needed, just update the check timestamp
 			log.Printf("[Work Hours Action] NO ACTION NEEDED for %s (Status: %s, Within hours: %v)", cluster.Name, cluster.Status, withinWorkHours)
-			if err := j.store.Clusters.UpdateLastWorkHoursCheck(ctx, cluster.ID); err != nil {
+			if err := j.stores.clusters.UpdateLastWorkHoursCheck(ctx, cluster.ID); err != nil {
 				log.Printf("Failed to update last_work_hours_check for cluster %s: %v", cluster.Name, err)
 			}
 			continue
@@ -769,7 +769,7 @@ func (j *Janitor) enforceWorkHours(ctx context.Context) error {
 		if cluster.Platform != types.PlatformAWS {
 			log.Printf("Skipping %s for cluster %s: platform %s does not support hibernation (AWS only)", action, cluster.Name, cluster.Platform)
 			// Update the check timestamp so we don't log this repeatedly
-			if err := j.store.Clusters.UpdateLastWorkHoursCheck(ctx, cluster.ID); err != nil {
+			if err := j.stores.clusters.UpdateLastWorkHoursCheck(ctx, cluster.ID); err != nil {
 				log.Printf("Failed to update last_work_hours_check for cluster %s: %v", cluster.Name, err)
 			}
 			continue
@@ -777,7 +777,7 @@ func (j *Janitor) enforceWorkHours(ctx context.Context) error {
 
 		// Check for ANY active jobs on this cluster
 		// We don't want to hibernate/resume while other jobs are running (POST_CONFIGURE, etc.)
-		allJobs, err := j.store.Jobs.ListByClusterID(ctx, cluster.ID)
+		allJobs, err := j.stores.jobs.ListByClusterID(ctx, cluster.ID)
 		if err != nil {
 			log.Printf("[Work Hours Action] CRITICAL: Failed to check for active jobs for cluster %s: %v", cluster.Name, err)
 			continue
@@ -806,7 +806,7 @@ func (j *Janitor) enforceWorkHours(ctx context.Context) error {
 			log.Printf("[Work Hours Action] Cluster %s has active %s job (ID: %s), skipping %s",
 				cluster.Name, activeJobType, activeJobID[:8], action)
 			// Update check timestamp so we don't spam logs
-			if err := j.store.Clusters.UpdateLastWorkHoursCheck(ctx, cluster.ID); err != nil {
+			if err := j.stores.clusters.UpdateLastWorkHoursCheck(ctx, cluster.ID); err != nil {
 				log.Printf("Failed to update last_work_hours_check for cluster %s: %v", cluster.Name, err)
 			}
 			continue
@@ -828,19 +828,19 @@ func (j *Janitor) enforceWorkHours(ctx context.Context) error {
 			UpdatedAt:   time.Now(),
 		}
 
-		if err := j.store.Jobs.Create(ctx, nil, job); err != nil {
+		if err := j.stores.jobs.Create(ctx, nil, job); err != nil {
 			log.Printf("Failed to create %s job for cluster %s: %v", action, cluster.Name, err)
 			continue
 		}
 
 		// Update cluster status
-		if err := j.store.Clusters.UpdateStatus(ctx, nil, cluster.ID, newStatus); err != nil {
+		if err := j.stores.clusters.UpdateStatus(ctx, nil, cluster.ID, newStatus); err != nil {
 			log.Printf("Failed to update cluster %s status to %s: %v", cluster.Name, newStatus, err)
 			continue
 		}
 
 		// Update last check timestamp
-		if err := j.store.Clusters.UpdateLastWorkHoursCheck(ctx, cluster.ID); err != nil {
+		if err := j.stores.clusters.UpdateLastWorkHoursCheck(ctx, cluster.ID); err != nil {
 			log.Printf("Failed to update last_work_hours_check for cluster %s: %v", cluster.Name, err)
 		}
 
@@ -882,7 +882,7 @@ func isWithinWorkHours(now time.Time, start, end time.Time, workDaysMask int16) 
 // This runs every 5 minutes (as part of the janitor cycle) to keep metrics fresh based on
 // the last 30 successful CREATE jobs per profile.
 func (j *Janitor) updateDeploymentMetrics(ctx context.Context) error {
-	count, err := j.store.ProfileDeploymentMetrics.UpdateAllMetrics(ctx)
+	count, err := j.stores.deployMetrics.UpdateAllMetrics(ctx)
 	if err != nil {
 		return err
 	}

--- a/internal/janitor/janitor_cleanup_test.go
+++ b/internal/janitor/janitor_cleanup_test.go
@@ -1,0 +1,519 @@
+package janitor
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/tsanders-rh/ocpctl/pkg/types"
+)
+
+// testJanitor wires a Janitor with mock store seams. metricsPublisher is left
+// nil (every use site is nil-guarded), and workDir defaults to a temp dir.
+type testMocks struct {
+	clusters *mockClusterStore
+	jobs     *mockJobStore
+	locks    *mockJobLockStore
+	idem     *mockIdempotencyStore
+	users    *mockUserStore
+	orphaned *mockOrphanedResourceStore
+	metrics  *mockDeploymentMetricsStore
+}
+
+func newTestJanitor(t *testing.T, cfg *Config) (*Janitor, *testMocks) {
+	t.Helper()
+	if cfg == nil {
+		cfg = DefaultConfig()
+	}
+	m := &testMocks{
+		clusters: &mockClusterStore{},
+		jobs:     &mockJobStore{},
+		locks:    &mockJobLockStore{},
+		idem:     &mockIdempotencyStore{},
+		users:    &mockUserStore{},
+		orphaned: &mockOrphanedResourceStore{},
+		metrics:  &mockDeploymentMetricsStore{},
+	}
+	j := &Janitor{
+		config:  cfg,
+		workDir: t.TempDir(),
+		stores: janitorStores{
+			clusters:      m.clusters,
+			jobs:          m.jobs,
+			jobLocks:      m.locks,
+			idempotency:   m.idem,
+			users:         m.users,
+			orphaned:      m.orphaned,
+			deployMetrics: m.metrics,
+		},
+	}
+	return j, m
+}
+
+func TestCleanupExpiredClusters(t *testing.T) {
+	t.Run("creates destroy job and marks destroying", func(t *testing.T) {
+		j, m := newTestJanitor(t, nil)
+		m.clusters.expired = []*types.Cluster{{ID: "c1", Name: "alpha"}}
+
+		if err := j.cleanupExpiredClusters(context.Background()); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(m.jobs.created) != 1 {
+			t.Fatalf("expected 1 job created, got %d", len(m.jobs.created))
+		}
+		job := m.jobs.created[0]
+		if job.JobType != types.JobTypeJanitorDestroy {
+			t.Errorf("expected JANITOR_DESTROY job, got %s", job.JobType)
+		}
+		if job.Metadata["reason"] != "TTL_EXPIRED" {
+			t.Errorf("expected reason TTL_EXPIRED, got %v", job.Metadata["reason"])
+		}
+		if len(m.clusters.statusUpdates) != 1 || m.clusters.statusUpdates[0].status != types.ClusterStatusDestroying {
+			t.Errorf("expected cluster marked DESTROYING, got %+v", m.clusters.statusUpdates)
+		}
+	})
+
+	t.Run("skips preserve_on_failure clusters", func(t *testing.T) {
+		j, m := newTestJanitor(t, nil)
+		m.clusters.expired = []*types.Cluster{{ID: "c1", Name: "keep", PreserveOnFailure: true}}
+
+		if err := j.cleanupExpiredClusters(context.Background()); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(m.jobs.created) != 0 {
+			t.Errorf("expected no jobs created, got %d", len(m.jobs.created))
+		}
+		if len(m.clusters.statusUpdates) != 0 {
+			t.Errorf("expected no status updates, got %+v", m.clusters.statusUpdates)
+		}
+	})
+
+	t.Run("skips clusters with existing destroy job", func(t *testing.T) {
+		j, m := newTestJanitor(t, nil)
+		m.clusters.expired = []*types.Cluster{{ID: "c1", Name: "busy"}}
+		m.jobs.byCluster = map[string][]*types.Job{
+			"c1": {{ID: "j1", JobType: types.JobTypeDestroy, Status: types.JobStatusPending}},
+		}
+
+		if err := j.cleanupExpiredClusters(context.Background()); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(m.jobs.created) != 0 {
+			t.Errorf("expected no new jobs, got %d", len(m.jobs.created))
+		}
+	})
+
+	t.Run("nothing expired", func(t *testing.T) {
+		j, m := newTestJanitor(t, nil)
+		if err := j.cleanupExpiredClusters(context.Background()); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(m.jobs.created) != 0 {
+			t.Errorf("expected no jobs, got %d", len(m.jobs.created))
+		}
+	})
+}
+
+func TestCleanupStuckJobs(t *testing.T) {
+	tests := []struct {
+		name         string
+		job          *types.Job
+		wantRetry    bool
+		wantFailed   bool
+		wantStatus   *types.ClusterStatus
+		wantReleased bool
+	}{
+		{
+			name:         "retry when attempts remain",
+			job:          &types.Job{ID: "j1", ClusterID: "c1", JobType: types.JobTypeCreate, Attempt: 1, MaxAttempts: 3},
+			wantRetry:    true,
+			wantReleased: true,
+		},
+		{
+			name:         "non-destroy exhausted marks cluster FAILED",
+			job:          &types.Job{ID: "j2", ClusterID: "c2", JobType: types.JobTypeCreate, Attempt: 3, MaxAttempts: 3},
+			wantFailed:   true,
+			wantStatus:   ptrStatus(types.ClusterStatusFailed),
+			wantReleased: true,
+		},
+		{
+			name:         "destroy exhausted marks cluster DESTROY_FAILED",
+			job:          &types.Job{ID: "j3", ClusterID: "c3", JobType: types.JobTypeDestroy, Attempt: 3, MaxAttempts: 3},
+			wantFailed:   true,
+			wantStatus:   ptrStatus(types.ClusterStatusDestroyFailed),
+			wantReleased: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			j, m := newTestJanitor(t, nil)
+			m.jobs.stuck = []*types.Job{tt.job}
+
+			if err := j.cleanupStuckJobs(context.Background()); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			gotRetry := len(m.jobs.markedRetry) == 1
+			if gotRetry != tt.wantRetry {
+				t.Errorf("retry: got %v want %v", gotRetry, tt.wantRetry)
+			}
+			gotFailed := len(m.jobs.markedFailed) == 1
+			if gotFailed != tt.wantFailed {
+				t.Errorf("failed: got %v want %v", gotFailed, tt.wantFailed)
+			}
+			if tt.wantReleased && len(m.locks.released) != 1 {
+				t.Errorf("expected lock released, got %v", m.locks.released)
+			}
+			if tt.wantStatus != nil {
+				if len(m.clusters.statusUpdates) != 1 || m.clusters.statusUpdates[0].status != *tt.wantStatus {
+					t.Errorf("expected status %s, got %+v", *tt.wantStatus, m.clusters.statusUpdates)
+				}
+			} else if len(m.clusters.statusUpdates) != 0 {
+				t.Errorf("expected no status update, got %+v", m.clusters.statusUpdates)
+			}
+		})
+	}
+}
+
+func TestCleanupIncompleteFailedJobs(t *testing.T) {
+	j, m := newTestJanitor(t, nil)
+	m.jobs.incomplete = []*types.Job{{ID: "j1", ClusterID: "c1", JobType: types.JobTypeCreate}}
+
+	if err := j.cleanupIncompleteFailedJobs(context.Background()); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(m.locks.released) != 1 {
+		t.Errorf("expected lock released, got %v", m.locks.released)
+	}
+	if len(m.jobs.completed) != 1 || m.jobs.completed[0] != "j1" {
+		t.Errorf("expected job j1 cleanup completed, got %v", m.jobs.completed)
+	}
+}
+
+func TestDetectStuckLocks(t *testing.T) {
+	j, m := newTestJanitor(t, nil)
+	m.locks.stuck = []*types.JobLock{
+		{ClusterID: "c1", JobID: "job12345-full", LockedBy: "worker-1", LockedAt: time.Now().Add(-2 * time.Hour), ExpiresAt: time.Now().Add(30 * time.Minute)},
+	}
+	// GetByID lookups for cluster/job intentionally miss (best-effort context).
+	if err := j.detectStuckLocks(context.Background()); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestCleanupExpiredLocksAndKeys(t *testing.T) {
+	j, m := newTestJanitor(t, nil)
+	m.locks.expiredN = 4
+	m.idem.expiredN = 7
+
+	if err := j.cleanupExpiredLocks(context.Background()); err != nil {
+		t.Fatalf("cleanupExpiredLocks: %v", err)
+	}
+	if err := j.cleanupExpiredKeys(context.Background()); err != nil {
+		t.Fatalf("cleanupExpiredKeys: %v", err)
+	}
+}
+
+func TestCleanupDestroyedClusters(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.DestroyedClusterRetentionDays = 30
+	j, m := newTestJanitor(t, cfg)
+	m.clusters.deleteN = 2
+
+	if err := j.cleanupDestroyedClusters(context.Background()); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Cutoff should be ~30 days ago.
+	wantCutoff := time.Now().AddDate(0, 0, -30)
+	if diff := m.clusters.deleteCutoff.Sub(wantCutoff); diff > time.Minute || diff < -time.Minute {
+		t.Errorf("cutoff off by %v (got %v, want ~%v)", diff, m.clusters.deleteCutoff, wantCutoff)
+	}
+}
+
+func TestCleanupFailedClusterDirs(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.FailedClusterDirRetentionDays = 7
+	j, m := newTestJanitor(t, cfg)
+
+	old := time.Now().AddDate(0, 0, -10)
+	recent := time.Now()
+
+	m.clusters.listResult = []*types.Cluster{
+		{ID: "old-failed", Name: "old", UpdatedAt: old},
+		{ID: "old-preserve", Name: "preserve", UpdatedAt: old, PreserveOnFailure: true},
+		{ID: "recent-failed", Name: "recent", UpdatedAt: recent},
+	}
+	for _, id := range []string{"old-failed", "old-preserve", "recent-failed"} {
+		if err := os.MkdirAll(filepath.Join(j.workDir, id), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if err := j.cleanupFailedClusterDirs(context.Background()); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	assertNotExist(t, filepath.Join(j.workDir, "old-failed"))
+	assertExist(t, filepath.Join(j.workDir, "old-preserve"))
+	assertExist(t, filepath.Join(j.workDir, "recent-failed"))
+}
+
+func TestCleanupOrphanedDirs(t *testing.T) {
+	j, m := newTestJanitor(t, nil)
+	m.clusters.streamBatches = [][]*types.Cluster{
+		{{ID: "valid-1"}},
+	}
+
+	// valid-1 has a DB record, orphan-1 does not; a stray file must be ignored.
+	if err := os.MkdirAll(filepath.Join(j.workDir, "valid-1"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(j.workDir, "orphan-1"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(j.workDir, "stray.txt"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := j.cleanupOrphanedDirs(context.Background()); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	assertExist(t, filepath.Join(j.workDir, "valid-1"))
+	assertNotExist(t, filepath.Join(j.workDir, "orphan-1"))
+	assertExist(t, filepath.Join(j.workDir, "stray.txt"))
+}
+
+func TestEnforceWorkHours(t *testing.T) {
+	// A user whose work-hours window covers the entire day (start==end triggers
+	// the wraparound branch => always within), and one that never has a work day.
+	alwaysOn := &types.User{ID: "u1", Email: "u1@x", Timezone: "UTC", WorkHoursEnabled: true, WorkDays: 0x7F, WorkHoursStart: midnight(), WorkHoursEnd: midnight()}
+	neverOn := &types.User{ID: "u1", Email: "u1@x", Timezone: "UTC", WorkHoursEnabled: true, WorkDays: 0, WorkHoursStart: midnight(), WorkHoursEnd: midnight()}
+
+	t.Run("hibernates READY AWS cluster outside hours", func(t *testing.T) {
+		j, m := newTestJanitor(t, nil)
+		m.users.byID = map[string]*types.User{"u1": neverOn}
+		m.clusters.forWorkHours = []*types.Cluster{
+			{ID: "c1", Name: "web", OwnerID: "u1", Status: types.ClusterStatusReady, Platform: types.PlatformAWS},
+		}
+
+		if err := j.enforceWorkHours(context.Background()); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(m.jobs.created) != 1 || m.jobs.created[0].JobType != types.JobTypeHibernate {
+			t.Fatalf("expected 1 hibernate job, got %+v", m.jobs.created)
+		}
+		if len(m.clusters.statusUpdates) != 1 || m.clusters.statusUpdates[0].status != types.ClusterStatusHibernating {
+			t.Errorf("expected HIBERNATING status, got %+v", m.clusters.statusUpdates)
+		}
+		if len(m.clusters.lastCheckIDs) != 1 {
+			t.Errorf("expected last-check updated, got %v", m.clusters.lastCheckIDs)
+		}
+	})
+
+	t.Run("resumes HIBERNATED AWS cluster within hours", func(t *testing.T) {
+		j, m := newTestJanitor(t, nil)
+		m.users.byID = map[string]*types.User{"u1": alwaysOn}
+		m.clusters.forWorkHours = []*types.Cluster{
+			{ID: "c1", Name: "web", OwnerID: "u1", Status: types.ClusterStatusHibernated, Platform: types.PlatformAWS},
+		}
+
+		if err := j.enforceWorkHours(context.Background()); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(m.jobs.created) != 1 || m.jobs.created[0].JobType != types.JobTypeResume {
+			t.Fatalf("expected 1 resume job, got %+v", m.jobs.created)
+		}
+		if len(m.clusters.statusUpdates) != 1 || m.clusters.statusUpdates[0].status != types.ClusterStatusResuming {
+			t.Errorf("expected RESUMING status, got %+v", m.clusters.statusUpdates)
+		}
+	})
+
+	t.Run("respects grace period", func(t *testing.T) {
+		j, m := newTestJanitor(t, nil)
+		future := time.Now().Add(time.Hour)
+		m.users.byID = map[string]*types.User{"u1": neverOn}
+		m.clusters.forWorkHours = []*types.Cluster{
+			{ID: "c1", Name: "web", OwnerID: "u1", Status: types.ClusterStatusReady, Platform: types.PlatformAWS, LastWorkHoursCheck: &future},
+		}
+
+		if err := j.enforceWorkHours(context.Background()); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(m.jobs.created) != 0 {
+			t.Errorf("expected no jobs during grace period, got %+v", m.jobs.created)
+		}
+		// Grace period is preserved: last-check timestamp is NOT touched.
+		if len(m.clusters.lastCheckIDs) != 0 {
+			t.Errorf("expected last-check untouched, got %v", m.clusters.lastCheckIDs)
+		}
+	})
+
+	t.Run("skips while post-deployment pending", func(t *testing.T) {
+		j, m := newTestJanitor(t, nil)
+		pending := "pending"
+		m.users.byID = map[string]*types.User{"u1": neverOn}
+		m.clusters.forWorkHours = []*types.Cluster{
+			{ID: "c1", Name: "web", OwnerID: "u1", Status: types.ClusterStatusReady, Platform: types.PlatformAWS, PostDeployStatus: &pending},
+		}
+
+		if err := j.enforceWorkHours(context.Background()); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(m.jobs.created) != 0 {
+			t.Errorf("expected no jobs, got %+v", m.jobs.created)
+		}
+		if len(m.clusters.lastCheckIDs) != 1 {
+			t.Errorf("expected last-check updated to throttle logs, got %v", m.clusters.lastCheckIDs)
+		}
+	})
+
+	t.Run("skips non-AWS platform", func(t *testing.T) {
+		j, m := newTestJanitor(t, nil)
+		m.users.byID = map[string]*types.User{"u1": neverOn}
+		m.clusters.forWorkHours = []*types.Cluster{
+			{ID: "c1", Name: "gke", OwnerID: "u1", Status: types.ClusterStatusReady, Platform: types.PlatformGCP},
+		}
+
+		if err := j.enforceWorkHours(context.Background()); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(m.jobs.created) != 0 {
+			t.Errorf("expected no jobs for non-AWS, got %+v", m.jobs.created)
+		}
+		if len(m.clusters.lastCheckIDs) != 1 {
+			t.Errorf("expected last-check updated, got %v", m.clusters.lastCheckIDs)
+		}
+	})
+
+	t.Run("skips when active job present", func(t *testing.T) {
+		j, m := newTestJanitor(t, nil)
+		m.users.byID = map[string]*types.User{"u1": neverOn}
+		m.clusters.forWorkHours = []*types.Cluster{
+			{ID: "c1", Name: "web", OwnerID: "u1", Status: types.ClusterStatusReady, Platform: types.PlatformAWS},
+		}
+		m.jobs.byCluster = map[string][]*types.Job{
+			"c1": {{ID: "job12345-active", JobType: types.JobTypePostConfigure, Status: types.JobStatusPending}},
+		}
+
+		if err := j.enforceWorkHours(context.Background()); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(m.jobs.created) != 0 {
+			t.Errorf("expected no hibernate job while active job runs, got %+v", m.jobs.created)
+		}
+		if len(m.clusters.lastCheckIDs) != 1 {
+			t.Errorf("expected last-check updated, got %v", m.clusters.lastCheckIDs)
+		}
+	})
+
+	t.Run("no action within hours updates check only", func(t *testing.T) {
+		j, m := newTestJanitor(t, nil)
+		m.users.byID = map[string]*types.User{"u1": alwaysOn}
+		m.clusters.forWorkHours = []*types.Cluster{
+			{ID: "c1", Name: "web", OwnerID: "u1", Status: types.ClusterStatusReady, Platform: types.PlatformAWS},
+		}
+
+		if err := j.enforceWorkHours(context.Background()); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(m.jobs.created) != 0 {
+			t.Errorf("expected no jobs, got %+v", m.jobs.created)
+		}
+		if len(m.clusters.lastCheckIDs) != 1 {
+			t.Errorf("expected last-check updated, got %v", m.clusters.lastCheckIDs)
+		}
+	})
+
+	t.Run("skips when work hours disabled", func(t *testing.T) {
+		j, m := newTestJanitor(t, nil)
+		disabled := &types.User{ID: "u1", Timezone: "UTC", WorkHoursEnabled: false}
+		m.users.byID = map[string]*types.User{"u1": disabled}
+		m.clusters.forWorkHours = []*types.Cluster{
+			{ID: "c1", Name: "web", OwnerID: "u1", Status: types.ClusterStatusReady, Platform: types.PlatformAWS},
+		}
+
+		if err := j.enforceWorkHours(context.Background()); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(m.jobs.created) != 0 || len(m.clusters.lastCheckIDs) != 0 {
+			t.Errorf("expected no action when work hours disabled")
+		}
+	})
+}
+
+func TestUpdateDeploymentMetrics(t *testing.T) {
+	j, m := newTestJanitor(t, nil)
+	m.metrics.updatedN = 5
+	if err := j.updateDeploymentMetrics(context.Background()); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// TestRun exercises the full cleanup orchestration against the mock seams. Cloud
+// orphan detection is disabled so run() doesn't reach the inline-constructed
+// AWS/GCP clients (those need the piece-2 client-interface refactor to test).
+func TestRun(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.OrphanDetection = false
+	j, m := newTestJanitor(t, cfg)
+	j.ctx = context.Background()
+
+	m.clusters.expired = []*types.Cluster{{ID: "c1", Name: "alpha"}}
+	m.jobs.stuck = []*types.Job{{ID: "j1", ClusterID: "c1", JobType: types.JobTypeCreate, Attempt: 1, MaxAttempts: 3}}
+	m.metrics.updatedN = 1
+
+	// run() logs and swallows per-task errors; it must not panic and must drive
+	// the sub-tasks (a destroy job is created for the expired cluster).
+	j.run()
+
+	if len(m.jobs.created) == 0 {
+		t.Errorf("expected run() to create a destroy job for the expired cluster")
+	}
+}
+
+func TestStartStop(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.OrphanDetection = false
+	cfg.CheckInterval = time.Hour // long enough that only the immediate run() fires
+	j, _ := newTestJanitor(t, cfg)
+
+	done := make(chan error, 1)
+	go func() { done <- j.Start(context.Background()) }()
+
+	// Give Start() a moment to perform its immediate run() and enter the loop.
+	time.Sleep(50 * time.Millisecond)
+	j.Stop()
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Errorf("expected Start to return the cancellation error")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Start did not return after Stop")
+	}
+}
+
+// --- helpers ---
+
+func ptrStatus(s types.ClusterStatus) *types.ClusterStatus { return &s }
+
+func midnight() time.Time { return time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC) }
+
+func assertExist(t *testing.T, path string) {
+	t.Helper()
+	if _, err := os.Stat(path); err != nil {
+		t.Errorf("expected %s to exist: %v", path, err)
+	}
+}
+
+func assertNotExist(t *testing.T, path string) {
+	t.Helper()
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Errorf("expected %s to be removed, stat err=%v", path, err)
+	}
+}

--- a/internal/janitor/orphan_detector.go
+++ b/internal/janitor/orphan_detector.go
@@ -175,7 +175,7 @@ func (j *Janitor) detectOrphanedResources(ctx context.Context) error {
 				Tags:         types.OrphanedResourceTags(orphan.Tags),
 			}
 
-			if err := j.store.OrphanedResources.Upsert(ctx, dbOrphan); err != nil {
+			if err := j.stores.orphaned.Upsert(ctx, dbOrphan); err != nil {
 				log.Printf("  WARNING: Failed to persist orphaned resource to database: %v", err)
 			}
 		}
@@ -1216,7 +1216,7 @@ func (j *Janitor) buildClusterLookupMaps(ctx context.Context) (map[string]*types
 	offset := 0
 	for {
 		// Fetch clusters in batches
-		batch, total, err := j.store.Clusters.List(ctx, store.ListFilters{
+		batch, total, err := j.stores.clusters.List(ctx, store.ListFilters{
 			Limit:  batchSize,
 			Offset: offset,
 		})

--- a/internal/janitor/orphaned_gcp.go
+++ b/internal/janitor/orphaned_gcp.go
@@ -114,7 +114,7 @@ func (j *Janitor) detectOrphanedGCPResources(ctx context.Context) error {
 				Tags:         types.OrphanedResourceTags(orphan.Tags),
 			}
 
-			if err := j.store.OrphanedResources.Upsert(ctx, dbOrphan); err != nil {
+			if err := j.stores.orphaned.Upsert(ctx, dbOrphan); err != nil {
 				log.Printf("  WARNING: Failed to persist orphaned resource to database: %v", err)
 			}
 		}

--- a/internal/janitor/stores.go
+++ b/internal/janitor/stores.go
@@ -1,0 +1,89 @@
+package janitor
+
+import (
+	"context"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/tsanders-rh/ocpctl/internal/store"
+	"github.com/tsanders-rh/ocpctl/pkg/types"
+)
+
+// The interfaces below capture exactly the store methods the janitor uses. They
+// exist so the janitor's DB-driven cleanup/safety logic can be unit-tested with
+// mocks instead of a live PostgreSQL pool. The concrete *store.ClusterStore
+// etc. satisfy them structurally, so production wiring (see storesFromStore) is
+// unchanged. Keep these method sets minimal — add a method only when the
+// janitor actually calls it.
+
+type clusterStore interface {
+	GetByID(ctx context.Context, id string) (*types.Cluster, error)
+	List(ctx context.Context, filters store.ListFilters) ([]*types.Cluster, int, error)
+	UpdateStatus(ctx context.Context, tx pgx.Tx, id string, status types.ClusterStatus) error
+	GetExpiredClusters(ctx context.Context) ([]*types.Cluster, error)
+	ListAllStreaming(ctx context.Context, batchSize int) (<-chan []*types.Cluster, <-chan error)
+	UpdateLastWorkHoursCheck(ctx context.Context, clusterID string) error
+	DeleteDestroyedClusters(ctx context.Context, olderThan time.Time) (int, error)
+	GetClustersForWorkHoursEnforcement(ctx context.Context) ([]*types.Cluster, error)
+}
+
+type jobStore interface {
+	Create(ctx context.Context, tx pgx.Tx, job *types.Job) error
+	GetByID(ctx context.Context, id string) (*types.Job, error)
+	ListByClusterID(ctx context.Context, clusterID string) ([]*types.Job, error)
+	MarkFailed(ctx context.Context, id string, errorCode, errorMessage string) error
+	MarkFailedForRetry(ctx context.Context, id string, errorCode, errorMessage string) error
+	GetStuckJobs(ctx context.Context, threshold time.Duration) ([]*types.Job, error)
+	GetIncompleteFailedJobs(ctx context.Context) ([]*types.Job, error)
+	CompleteFailedJobCleanup(ctx context.Context, id string) error
+}
+
+type jobLockStore interface {
+	Release(ctx context.Context, clusterID, jobID string) error
+	CleanupExpired(ctx context.Context) (int64, error)
+	GetStuckLocks(ctx context.Context, stuckThreshold time.Duration) ([]*types.JobLock, error)
+}
+
+type idempotencyStore interface {
+	CleanupExpired(ctx context.Context) (int64, error)
+}
+
+type userStore interface {
+	GetByID(ctx context.Context, id string) (*types.User, error)
+}
+
+type orphanedResourceStore interface {
+	Upsert(ctx context.Context, resource *types.OrphanedResource) error
+}
+
+type deploymentMetricsStore interface {
+	UpdateAllMetrics(ctx context.Context) (int, error)
+}
+
+// janitorStores groups the store seams the janitor depends on.
+type janitorStores struct {
+	clusters      clusterStore
+	jobs          jobStore
+	jobLocks      jobLockStore
+	idempotency   idempotencyStore
+	users         userStore
+	orphaned      orphanedResourceStore
+	deployMetrics deploymentMetricsStore
+}
+
+// storesFromStore adapts a concrete *store.Store into the interface seams. A nil
+// store yields empty seams (used only by tests that inject their own mocks).
+func storesFromStore(st *store.Store) janitorStores {
+	if st == nil {
+		return janitorStores{}
+	}
+	return janitorStores{
+		clusters:      st.Clusters,
+		jobs:          st.Jobs,
+		jobLocks:      st.JobLocks,
+		idempotency:   st.Idempotency,
+		users:         st.Users,
+		orphaned:      st.OrphanedResources,
+		deployMetrics: st.ProfileDeploymentMetrics,
+	}
+}

--- a/internal/janitor/stores_mock_test.go
+++ b/internal/janitor/stores_mock_test.go
@@ -1,0 +1,224 @@
+package janitor
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/tsanders-rh/ocpctl/internal/store"
+	"github.com/tsanders-rh/ocpctl/pkg/types"
+)
+
+// These mocks satisfy the janitor store seams (see stores.go) so the DB-driven
+// cleanup/safety methods can be exercised without a live PostgreSQL pool. Each
+// mock records the mutating calls the tests assert on and returns preconfigured
+// data for the reads.
+
+type statusUpdate struct {
+	id     string
+	status types.ClusterStatus
+}
+
+type mockClusterStore struct {
+	// reads
+	expired         []*types.Cluster
+	expiredErr      error
+	listResult      []*types.Cluster
+	listErr         error
+	forWorkHours    []*types.Cluster
+	forWorkHoursErr error
+	byID            map[string]*types.Cluster
+	streamBatches   [][]*types.Cluster
+	streamErr       error
+	deleteN         int
+	deleteErr       error
+	updateStatusErr error
+
+	// recorded writes
+	statusUpdates []statusUpdate
+	lastCheckIDs  []string
+	deleteCutoff  time.Time
+}
+
+func (m *mockClusterStore) GetByID(ctx context.Context, id string) (*types.Cluster, error) {
+	if m.byID != nil {
+		if c, ok := m.byID[id]; ok {
+			return c, nil
+		}
+	}
+	return nil, fmt.Errorf("cluster %s not found", id)
+}
+
+func (m *mockClusterStore) List(ctx context.Context, filters store.ListFilters) ([]*types.Cluster, int, error) {
+	return m.listResult, len(m.listResult), m.listErr
+}
+
+func (m *mockClusterStore) UpdateStatus(ctx context.Context, tx pgx.Tx, id string, status types.ClusterStatus) error {
+	m.statusUpdates = append(m.statusUpdates, statusUpdate{id: id, status: status})
+	return m.updateStatusErr
+}
+
+func (m *mockClusterStore) GetExpiredClusters(ctx context.Context) ([]*types.Cluster, error) {
+	return m.expired, m.expiredErr
+}
+
+func (m *mockClusterStore) ListAllStreaming(ctx context.Context, batchSize int) (<-chan []*types.Cluster, <-chan error) {
+	ch := make(chan []*types.Cluster, len(m.streamBatches)+1)
+	errCh := make(chan error, 1)
+	if m.streamErr != nil {
+		// Leave ch open and empty so the janitor's select fires the error case.
+		errCh <- m.streamErr
+		return ch, errCh
+	}
+	for _, b := range m.streamBatches {
+		ch <- b
+	}
+	close(ch)
+	close(errCh)
+	return ch, errCh
+}
+
+func (m *mockClusterStore) UpdateLastWorkHoursCheck(ctx context.Context, clusterID string) error {
+	m.lastCheckIDs = append(m.lastCheckIDs, clusterID)
+	return nil
+}
+
+func (m *mockClusterStore) DeleteDestroyedClusters(ctx context.Context, olderThan time.Time) (int, error) {
+	m.deleteCutoff = olderThan
+	return m.deleteN, m.deleteErr
+}
+
+func (m *mockClusterStore) GetClustersForWorkHoursEnforcement(ctx context.Context) ([]*types.Cluster, error) {
+	return m.forWorkHours, m.forWorkHoursErr
+}
+
+type mockJobStore struct {
+	// reads
+	byCluster     map[string][]*types.Job
+	listErr       error
+	byID          map[string]*types.Job
+	stuck         []*types.Job
+	stuckErr      error
+	incomplete    []*types.Job
+	incompleteErr error
+	createErr     error
+
+	// recorded writes
+	created      []*types.Job
+	markedFailed []string
+	markedRetry  []string
+	completed    []string
+}
+
+func (m *mockJobStore) Create(ctx context.Context, tx pgx.Tx, job *types.Job) error {
+	if m.createErr != nil {
+		return m.createErr
+	}
+	m.created = append(m.created, job)
+	return nil
+}
+
+func (m *mockJobStore) GetByID(ctx context.Context, id string) (*types.Job, error) {
+	if m.byID != nil {
+		if j, ok := m.byID[id]; ok {
+			return j, nil
+		}
+	}
+	return nil, fmt.Errorf("job %s not found", id)
+}
+
+func (m *mockJobStore) ListByClusterID(ctx context.Context, clusterID string) ([]*types.Job, error) {
+	if m.listErr != nil {
+		return nil, m.listErr
+	}
+	if m.byCluster != nil {
+		return m.byCluster[clusterID], nil
+	}
+	return nil, nil
+}
+
+func (m *mockJobStore) MarkFailed(ctx context.Context, id, errorCode, errorMessage string) error {
+	m.markedFailed = append(m.markedFailed, id)
+	return nil
+}
+
+func (m *mockJobStore) MarkFailedForRetry(ctx context.Context, id, errorCode, errorMessage string) error {
+	m.markedRetry = append(m.markedRetry, id)
+	return nil
+}
+
+func (m *mockJobStore) GetStuckJobs(ctx context.Context, threshold time.Duration) ([]*types.Job, error) {
+	return m.stuck, m.stuckErr
+}
+
+func (m *mockJobStore) GetIncompleteFailedJobs(ctx context.Context) ([]*types.Job, error) {
+	return m.incomplete, m.incompleteErr
+}
+
+func (m *mockJobStore) CompleteFailedJobCleanup(ctx context.Context, id string) error {
+	m.completed = append(m.completed, id)
+	return nil
+}
+
+type mockJobLockStore struct {
+	expiredN int64
+	stuck    []*types.JobLock
+	stuckErr error
+
+	released []string // "clusterID:jobID"
+}
+
+func (m *mockJobLockStore) Release(ctx context.Context, clusterID, jobID string) error {
+	m.released = append(m.released, clusterID+":"+jobID)
+	return nil
+}
+
+func (m *mockJobLockStore) CleanupExpired(ctx context.Context) (int64, error) {
+	return m.expiredN, nil
+}
+
+func (m *mockJobLockStore) GetStuckLocks(ctx context.Context, stuckThreshold time.Duration) ([]*types.JobLock, error) {
+	return m.stuck, m.stuckErr
+}
+
+type mockIdempotencyStore struct {
+	expiredN int64
+	err      error
+}
+
+func (m *mockIdempotencyStore) CleanupExpired(ctx context.Context) (int64, error) {
+	return m.expiredN, m.err
+}
+
+type mockUserStore struct {
+	byID map[string]*types.User
+}
+
+func (m *mockUserStore) GetByID(ctx context.Context, id string) (*types.User, error) {
+	if m.byID != nil {
+		if u, ok := m.byID[id]; ok {
+			return u, nil
+		}
+	}
+	return nil, fmt.Errorf("user %s not found", id)
+}
+
+type mockOrphanedResourceStore struct {
+	upserts []*types.OrphanedResource
+	err     error
+}
+
+func (m *mockOrphanedResourceStore) Upsert(ctx context.Context, resource *types.OrphanedResource) error {
+	m.upserts = append(m.upserts, resource)
+	return m.err
+}
+
+type mockDeploymentMetricsStore struct {
+	updatedN int
+	err      error
+}
+
+func (m *mockDeploymentMetricsStore) UpdateAllMetrics(ctx context.Context) (int, error) {
+	return m.updatedN, m.err
+}

--- a/scripts/check-coverage.sh
+++ b/scripts/check-coverage.sh
@@ -25,17 +25,20 @@ cd "$(dirname "$0")/.."
 # pkg:floor (minimum statement coverage %, integer).
 # PR3 will add: internal/api/middleware, internal/poolscheduler, internal/auth (full)
 #
-# NOTE on internal/janitor: its floor covers only the pure classification/safety
-# helpers (orphan name/tag parsing, work-hours math). The bulk of the package is
-# DB- and cloud-bound methods whose dependencies (concrete pgxpool-backed stores
-# and inline-constructed AWS/GCP clients) are not injectable, so they can't be
-# unit-tested without a store/client-interface refactor. Raise this floor once
-# that refactor lands; until then it is an anti-regression gate on the helpers.
+# NOTE on internal/janitor: a store-interface seam (stores.go) now makes the
+# DB-driven safety/cleanup logic unit-testable, and janitor.go (the TTL reaper,
+# stuck-job recovery, work-hours hibernate/resume, directory cleanup, run/Start
+# orchestration) is ~80% covered. The PACKAGE total is nonetheless ~30% because
+# ~67% of the package's lines are the AWS/GCP orphan detectors
+# (orphan_detector.go, orphaned_gcp.go), which construct cloud clients inline and
+# cannot be unit-tested without a further client-interface refactor ("piece 2").
+# This floor gates the tested core against regression; raise it toward 60% only
+# after piece 2 lands and the detectors become mockable.
 FLOORS=(
   "internal/validation:90"
   "internal/secrets:65"
   "internal/aws/cleanup:70"
-  "internal/janitor:7"
+  "internal/janitor:28"
 )
 
 profile="$(mktemp)"


### PR DESCRIPTION
## Summary

Extracts a store-interface seam into the janitor so its DB-driven safety and
cleanup logic can be unit-tested with mocks instead of a live PostgreSQL pool,
then backfills tests for that logic. Continues the #102 risk-first coverage
work (follows #106 coverage floors and #107 cleanup/janitor-helper tests).

## What changed

- **`internal/janitor/stores.go`** — narrow interfaces capturing exactly the
  store methods the janitor calls (clusters, jobs, jobLocks, idempotency,
  users, orphaned resources, deployment metrics). The concrete
  `*store.ClusterStore` etc. satisfy them structurally, so `NewJanitor` and all
  production wiring are unchanged — a nil store yields empty seams used only by
  tests.
- **`internal/janitor/janitor.go`** — `store *store.Store` field replaced with
  the interface-backed `stores janitorStores`; all `j.store.X` call sites
  rewritten. No behavior change.
- **Tests** (`stores_mock_test.go`, `janitor_cleanup_test.go`) cover the safety
  gates that matter for the #101 blast radius:
  - `cleanupExpiredClusters` — `preserve_on_failure` skip, de-dup of destroy jobs
  - `cleanupStuckJobs` — retry vs exhausted; destroy -> `DESTROY_FAILED`, other -> `FAILED`
  - `cleanupIncompleteFailedJobs`, `detectStuckLocks`, expired lock/key cleanup
  - `cleanupDestroyedClusters` retention cutoff
  - `cleanupFailedClusterDirs` / `cleanupOrphanedDirs` via `t.TempDir()`
  - `enforceWorkHours` — grace period, post-deploy pending, non-AWS platform, and active-job gates; hibernate/resume happy paths
  - `run` / `Start` / `Stop` orchestration

## Coverage

`janitor.go` (the tested core) is now ~80% covered. The **package** total is
~30% because ~67% of the package's lines are the AWS/GCP orphan detectors
(`orphan_detector.go`, `orphaned_gcp.go`), which construct cloud clients inline
and need a further client-interface refactor ("piece 2") to be mockable.

Floor raised `internal/janitor: 7 -> 28` to gate the newly tested core against
regression; the `scripts/check-coverage.sh` NOTE documents why 60% waits on
piece 2.

## Test plan
- `./scripts/check-coverage.sh` — all floors pass (janitor 30.4% vs floor 28%)
- `go build ./...` clean