### PR TITLE
Unit tests for middleware, auth, k8s, s3, poolscheduler (PR3, #102)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -84,6 +84,7 @@ require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/emicklei/go-restful/v3 v3.9.0 // indirect
+	github.com/evanphx/json-patch v5.6.0+incompatible // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.11 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
@@ -130,6 +131,7 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/oklog/ulid v1.3.1 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.66.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -87,6 +87,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/emicklei/go-restful/v3 v3.9.0 h1:XwGDlfxEnQZzuopoqxwSEllNcCOM9DhhFyhFIIGKwxE=
 github.com/emicklei/go-restful/v3 v3.9.0/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry+4bhvbpWn3mrbc=
+github.com/evanphx/json-patch v5.6.0+incompatible h1:jBYDEEiFBPxA0v50tFdvOzQQTCvpL6mnFh5mB2/l16U=
+github.com/evanphx/json-patch v5.6.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/fatih/color v1.16.0 h1:zmkK9Ngbjj+K0yRhTVONQh1p/HknKYSlNT+vZCzyokM=
 github.com/fatih/color v1.16.0/go.mod h1:fL2Sau1YI5c0pdGEVCbKQbLXB6edEj1ZgiY4NijnWvE=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
@@ -231,6 +233,8 @@ github.com/onsi/ginkgo/v2 v2.9.4 h1:xR7vG4IXt5RWx6FfIjyAtsoMAtnc3C/rFXBBd2AjZwE=
 github.com/onsi/ginkgo/v2 v2.9.4/go.mod h1:gCQYp2Q+kSoIj7ykSVb9nskRSsR6PUj4AiLywzIhbKM=
 github.com/onsi/gomega v1.37.0 h1:CdEG8g0S133B4OswTDC/5XPSzE1OeP29QOioj2PID2Y=
 github.com/onsi/gomega v1.37.0/go.mod h1:8D9+Txp43QWKhM24yyOBEdpkzN8FvJyAwecBgsU4KU0=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_golang v1.23.2 h1:Je96obch5RDVy3FDMndoUsjAhG5Edi49h0RJWRi/o0o=

--- a/internal/api/middleware/middleware_test.go
+++ b/internal/api/middleware/middleware_test.go
@@ -1,0 +1,157 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/labstack/echo/v4"
+)
+
+// newCtx builds an Echo context backed by httptest for exercising middleware.
+func newCtx(method, target string) (echo.Context, *httptest.ResponseRecorder) {
+	e := echo.New()
+	req := httptest.NewRequest(method, target, nil)
+	req.RemoteAddr = "1.2.3.4:5678"
+	rec := httptest.NewRecorder()
+	return e.NewContext(req, rec), rec
+}
+
+// okHandler writes a 200 response.
+func okHandler(c echo.Context) error { return c.String(http.StatusOK, "ok") }
+
+func TestCacheControl(t *testing.T) {
+	tests := []struct {
+		name string
+		mw   echo.MiddlewareFunc
+		want string
+	}{
+		{"public ttl", CacheControl(60), "public, max-age=60"},
+		{"no-cache ttl 0", CacheControl(0), "no-cache, private"},
+		{"no-store ttl -1", CacheControl(-1), "private, no-store, must-revalidate"},
+		{"NoCache", NoCache(), "private, no-store, must-revalidate"},
+		{"CachePublic", CachePublic(2 * time.Minute), "public, max-age=120"},
+		{"CachePrivate", CachePrivate(90 * time.Second), "private, max-age=90"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c, rec := newCtx(http.MethodGet, "/")
+			if err := tt.mw(okHandler)(c); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got := rec.Header().Get("Cache-Control"); got != tt.want {
+				t.Errorf("Cache-Control = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCacheControlSkipsOnError(t *testing.T) {
+	c, rec := newCtx(http.MethodGet, "/")
+	failing := func(c echo.Context) error { return echo.NewHTTPError(http.StatusInternalServerError, "boom") }
+	if err := CacheControl(60)(failing)(c); err == nil {
+		t.Fatal("expected error to propagate")
+	}
+	if got := rec.Header().Get("Cache-Control"); got != "" {
+		t.Errorf("expected no Cache-Control on error, got %q", got)
+	}
+}
+
+func TestRateLimiterStore(t *testing.T) {
+	s := NewRateLimiterStore(60, 5)
+	l1 := s.getLimiter("10.0.0.1")
+	l2 := s.getLimiter("10.0.0.1")
+	if l1 != l2 {
+		t.Error("expected same limiter for same IP")
+	}
+	if l3 := s.getLimiter("10.0.0.2"); l3 == l1 {
+		t.Error("expected distinct limiter for different IP")
+	}
+}
+
+func TestRateLimitBlocksOverBurst(t *testing.T) {
+	mw := RateLimit(60, 1) // burst of 1: first request passes, second is throttled
+	handler := mw(okHandler)
+
+	c1, _ := newCtx(http.MethodGet, "/")
+	if err := handler(c1); err != nil {
+		t.Fatalf("first request should pass, got %v", err)
+	}
+
+	c2, _ := newCtx(http.MethodGet, "/")
+	err := handler(c2)
+	he, ok := err.(*echo.HTTPError)
+	if !ok || he.Code != http.StatusTooManyRequests {
+		t.Fatalf("second request should be rate limited, got %v", err)
+	}
+}
+
+func TestRateLimitWithMessage(t *testing.T) {
+	mw := StrictRateLimitWithMessage(60, "slow down")
+	handler := mw(okHandler)
+
+	c1, _ := newCtx(http.MethodGet, "/")
+	if err := handler(c1); err != nil {
+		t.Fatalf("first request should pass, got %v", err)
+	}
+	c2, _ := newCtx(http.MethodGet, "/")
+	err := handler(c2)
+	he, ok := err.(*echo.HTTPError)
+	if !ok || he.Code != http.StatusTooManyRequests {
+		t.Fatalf("expected 429, got %v", err)
+	}
+	if msg, _ := he.Message.(string); !strings.Contains(msg, "slow down") {
+		t.Errorf("expected custom message, got %v", he.Message)
+	}
+}
+
+func TestStrictRateLimit(t *testing.T) {
+	handler := StrictRateLimit(60)(okHandler)
+	c1, _ := newCtx(http.MethodGet, "/")
+	if err := handler(c1); err != nil {
+		t.Fatalf("first request should pass, got %v", err)
+	}
+	c2, _ := newCtx(http.MethodGet, "/")
+	if err := handler(c2); err == nil {
+		t.Error("expected strict limiter to throttle the second request")
+	}
+}
+
+func TestPrometheusMetrics(t *testing.T) {
+	// Normal request path records metrics and passes through.
+	c, _ := newCtx(http.MethodGet, "/api/v1/clusters")
+	c.SetPath("/api/v1/clusters")
+	if err := PrometheusMetrics()(okHandler)(c); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// A handler that writes nothing leaves status 0; middleware normalizes to 200.
+	c2, _ := newCtx(http.MethodGet, "/noop")
+	c2.SetPath("/noop")
+	noWrite := func(c echo.Context) error { return nil }
+	if err := PrometheusMetrics()(noWrite)(c2); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestPrometheusMetricsSkipsMetricsEndpoint(t *testing.T) {
+	c, _ := newCtx(http.MethodGet, "/metrics")
+	c.SetPath("/metrics")
+	called := false
+	handler := func(c echo.Context) error { called = true; return nil }
+	if err := PrometheusMetrics()(handler)(c); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !called {
+		t.Error("expected next handler to run for /metrics")
+	}
+}
+
+func TestLogger(t *testing.T) {
+	c, _ := newCtx(http.MethodGet, "/")
+	if err := Logger()(okHandler)(c); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/internal/auth/apikey_extra_test.go
+++ b/internal/auth/apikey_extra_test.go
@@ -1,0 +1,64 @@
+package auth
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func requestWithAuth(header string) *http.Request {
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	if header != "" {
+		r.Header.Set("Authorization", header)
+	}
+	return r
+}
+
+func TestValidateAPIKeyRejectsBadFormat(t *testing.T) {
+	// A key without the ocpctl_ prefix is rejected before any store lookup, so a
+	// nil store is safe here.
+	if _, err := ValidateAPIKey(context.Background(), nil, "not-an-ocpctl-key"); err == nil {
+		t.Error("expected error for key without prefix")
+	}
+}
+
+func TestValidateAPIKeyFromContextWrongStoreType(t *testing.T) {
+	if _, err := ValidateAPIKeyFromContext(context.Background(), "not-a-store", APIKeyPrefix+"abc"); err == nil {
+		t.Error("expected error for non-*store.Store value")
+	}
+}
+
+func TestIsIAMRequest(t *testing.T) {
+	tests := []struct {
+		name   string
+		header string
+		want   bool
+	}{
+		{"sigv4", "AWS4-HMAC-SHA256 Credential=AKIA...", true},
+		{"bearer", "Bearer abc", false},
+		{"empty", "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := requestWithAuth(tt.header)
+			if got := IsIAMRequest(r); got != tt.want {
+				t.Errorf("IsIAMRequest(%q) = %v, want %v", tt.header, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNewIAMAuthenticatorDisabled(t *testing.T) {
+	// Disabled path must not touch AWS config; it returns a usable, disabled auth.
+	iamAuth, err := NewIAMAuthenticator(nil, nil, false, "my-group")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if iamAuth.enabledIAMAuth {
+		t.Error("expected IAM auth to be disabled")
+	}
+	if _, err := iamAuth.ValidateIAMRequest(context.Background(), requestWithAuth("AWS4-HMAC-SHA256 x")); err == nil {
+		t.Error("expected disabled authenticator to reject validation")
+	}
+}

--- a/internal/auth/middleware_test.go
+++ b/internal/auth/middleware_test.go
@@ -1,0 +1,286 @@
+package auth
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/labstack/echo/v4"
+	"github.com/tsanders-rh/ocpctl/pkg/types"
+)
+
+func testAuth() *Auth { return NewAuth("test-secret", time.Hour, 24*time.Hour) }
+
+func newEchoCtx(authHeader string) (echo.Context, *httptest.ResponseRecorder) {
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	if authHeader != "" {
+		req.Header.Set("Authorization", authHeader)
+	}
+	rec := httptest.NewRecorder()
+	return e.NewContext(req, rec), rec
+}
+
+func tokenFor(t *testing.T, a *Auth, role types.UserRole) string {
+	t.Helper()
+	tok, err := a.GenerateAccessToken(&types.User{ID: "u1", Email: "u1@x", Role: role})
+	if err != nil {
+		t.Fatalf("generate token: %v", err)
+	}
+	return tok
+}
+
+func httpCode(err error) int {
+	if he, ok := err.(*echo.HTTPError); ok {
+		return he.Code
+	}
+	return 0
+}
+
+func pass(c echo.Context) error { return c.String(http.StatusOK, "ok") }
+
+func TestRequireAuth(t *testing.T) {
+	a := testAuth()
+
+	t.Run("missing header", func(t *testing.T) {
+		c, _ := newEchoCtx("")
+		if code := httpCode(RequireAuth(a)(pass)(c)); code != http.StatusUnauthorized {
+			t.Errorf("got %d want 401", code)
+		}
+	})
+	t.Run("bad format", func(t *testing.T) {
+		c, _ := newEchoCtx("Basic abc")
+		if code := httpCode(RequireAuth(a)(pass)(c)); code != http.StatusUnauthorized {
+			t.Errorf("got %d want 401", code)
+		}
+	})
+	t.Run("invalid token", func(t *testing.T) {
+		c, _ := newEchoCtx("Bearer not-a-jwt")
+		if code := httpCode(RequireAuth(a)(pass)(c)); code != http.StatusUnauthorized {
+			t.Errorf("got %d want 401", code)
+		}
+	})
+	t.Run("valid token sets claims", func(t *testing.T) {
+		c, _ := newEchoCtx("Bearer " + tokenFor(t, a, types.RoleUser))
+		if err := RequireAuth(a)(pass)(c); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if _, ok := c.Get(string(ClaimsContextKey)).(*Claims); !ok {
+			t.Error("expected claims stored in context")
+		}
+	})
+}
+
+func TestRequireRoleAndAdmin(t *testing.T) {
+	setClaims := func(role types.UserRole) echo.Context {
+		c, _ := newEchoCtx("")
+		c.Set(string(ClaimsContextKey), &Claims{UserID: "u1", Role: string(role)})
+		return c
+	}
+
+	t.Run("no claims", func(t *testing.T) {
+		c, _ := newEchoCtx("")
+		if code := httpCode(RequireRole(types.RoleAdmin)(pass)(c)); code != http.StatusUnauthorized {
+			t.Errorf("got %d want 401", code)
+		}
+	})
+	t.Run("wrong role", func(t *testing.T) {
+		if code := httpCode(RequireRole(types.RoleAdmin)(pass)(setClaims(types.RoleUser))); code != http.StatusForbidden {
+			t.Errorf("got %d want 403", code)
+		}
+	})
+	t.Run("right role", func(t *testing.T) {
+		if err := RequireRole(types.RoleUser)(pass)(setClaims(types.RoleUser)); err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+	})
+	t.Run("RequireAdmin allows admin", func(t *testing.T) {
+		if err := RequireAdmin()(pass)(setClaims(types.RoleAdmin)); err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+	})
+	t.Run("RequireTeamAdmin allows team admin and admin", func(t *testing.T) {
+		if err := RequireTeamAdmin()(pass)(setClaims(types.RoleTeamAdmin)); err != nil {
+			t.Errorf("team admin: %v", err)
+		}
+		if err := RequireTeamAdmin()(pass)(setClaims(types.RoleAdmin)); err != nil {
+			t.Errorf("admin: %v", err)
+		}
+		if code := httpCode(RequireTeamAdmin()(pass)(setClaims(types.RoleUser))); code != http.StatusForbidden {
+			t.Errorf("user got %d want 403", code)
+		}
+	})
+}
+
+func TestOptionalAuth(t *testing.T) {
+	a := testAuth()
+	cases := []struct {
+		name       string
+		header     string
+		wantClaims bool
+	}{
+		{"no header", "", false},
+		{"bad format", "Basic abc", false},
+		{"invalid token", "Bearer nope", false},
+		{"valid token", "Bearer " + tokenFor(t, a, types.RoleUser), true},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			c, _ := newEchoCtx(tt.header)
+			if err := OptionalAuth(a)(pass)(c); err != nil {
+				t.Fatalf("OptionalAuth must never fail, got %v", err)
+			}
+			_, ok := c.Get(string(ClaimsContextKey)).(*Claims)
+			if ok != tt.wantClaims {
+				t.Errorf("claims present = %v, want %v", ok, tt.wantClaims)
+			}
+		})
+	}
+}
+
+func TestContextGetters(t *testing.T) {
+	t.Run("claims present", func(t *testing.T) {
+		c, _ := newEchoCtx("")
+		c.Set(string(ClaimsContextKey), &Claims{UserID: "u1", Role: string(types.RoleAdmin)})
+		claims, err := GetClaims(c)
+		if err != nil || claims.UserID != "u1" {
+			t.Errorf("GetClaims: %v %+v", err, claims)
+		}
+		if id, _ := GetUserID(c); id != "u1" {
+			t.Errorf("GetUserID from claims = %q", id)
+		}
+		if role, _ := GetUserRole(c); role != types.RoleAdmin {
+			t.Errorf("GetUserRole from claims = %q", role)
+		}
+		if !IsAdmin(c) {
+			t.Error("IsAdmin should be true")
+		}
+		if !IsTeamAdmin(c) {
+			t.Error("IsTeamAdmin should be true for admin")
+		}
+	})
+
+	t.Run("claims absent", func(t *testing.T) {
+		c, _ := newEchoCtx("")
+		if _, err := GetClaims(c); err == nil {
+			t.Error("expected error for missing claims")
+		}
+		if _, err := GetUser(c); err == nil {
+			t.Error("expected error for missing user")
+		}
+		if _, err := GetUserID(c); err == nil {
+			t.Error("expected error for missing user id")
+		}
+		if _, err := GetUserRole(c); err == nil {
+			t.Error("expected error for missing role")
+		}
+		if IsAdmin(c) || IsTeamAdmin(c) {
+			t.Error("IsAdmin/IsTeamAdmin should be false without claims")
+		}
+		if teams := GetManagedTeams(c); len(teams) != 0 {
+			t.Errorf("expected no managed teams, got %v", teams)
+		}
+	})
+
+	t.Run("user object present", func(t *testing.T) {
+		c, _ := newEchoCtx("")
+		c.Set(string(UserContextKey), &types.User{ID: "u9", Role: types.RoleTeamAdmin, ManagedTeams: []string{"team-a"}})
+		if u, err := GetUser(c); err != nil || u.ID != "u9" {
+			t.Errorf("GetUser: %v %+v", err, u)
+		}
+		if id, _ := GetUserID(c); id != "u9" {
+			t.Errorf("GetUserID from user = %q", id)
+		}
+		if role, _ := GetUserRole(c); role != types.RoleTeamAdmin {
+			t.Errorf("GetUserRole from user = %q", role)
+		}
+		if teams := GetManagedTeams(c); len(teams) != 1 || teams[0] != "team-a" {
+			t.Errorf("GetManagedTeams = %v", teams)
+		}
+	})
+}
+
+func TestCanManageTeam(t *testing.T) {
+	t.Run("admin manages any team", func(t *testing.T) {
+		c, _ := newEchoCtx("")
+		c.Set(string(UserContextKey), &types.User{ID: "a", Role: types.RoleAdmin})
+		if !CanManageTeam(c, "anything") {
+			t.Error("admin should manage any team")
+		}
+	})
+	t.Run("team admin manages only assigned teams", func(t *testing.T) {
+		c, _ := newEchoCtx("")
+		c.Set(string(UserContextKey), &types.User{ID: "t", Role: types.RoleTeamAdmin, ManagedTeams: []string{"team-a"}})
+		if !CanManageTeam(c, "team-a") {
+			t.Error("should manage assigned team")
+		}
+		if CanManageTeam(c, "team-b") {
+			t.Error("should not manage unassigned team")
+		}
+	})
+	t.Run("regular user manages nothing", func(t *testing.T) {
+		c, _ := newEchoCtx("")
+		c.Set(string(UserContextKey), &types.User{ID: "u", Role: types.RoleUser})
+		if CanManageTeam(c, "team-a") {
+			t.Error("regular user should not manage teams")
+		}
+	})
+	t.Run("no user in context", func(t *testing.T) {
+		c, _ := newEchoCtx("")
+		if CanManageTeam(c, "team-a") {
+			t.Error("no user should not manage teams")
+		}
+	})
+}
+
+func TestRequireAuthDual(t *testing.T) {
+	a := testAuth()
+	disabledIAM, _ := NewIAMAuthenticator(nil, nil, false, "")
+
+	t.Run("missing header", func(t *testing.T) {
+		c, _ := newEchoCtx("")
+		if code := httpCode(RequireAuthDual(a, disabledIAM)(pass)(c)); code != http.StatusUnauthorized {
+			t.Errorf("got %d want 401", code)
+		}
+	})
+
+	t.Run("valid JWT sets user", func(t *testing.T) {
+		c, _ := newEchoCtx("Bearer " + tokenFor(t, a, types.RoleUser))
+		if err := RequireAuthDual(a, disabledIAM)(pass)(c); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if u, ok := c.Get(string(UserContextKey)).(*types.User); !ok || u.ID != "u1" {
+			t.Errorf("expected user set from JWT, got %+v", c.Get(string(UserContextKey)))
+		}
+	})
+
+	t.Run("bad bearer format", func(t *testing.T) {
+		c, _ := newEchoCtx("Bearer")
+		if code := httpCode(RequireAuthDual(a, disabledIAM)(pass)(c)); code != http.StatusUnauthorized {
+			t.Errorf("got %d want 401", code)
+		}
+	})
+
+	t.Run("API key without store errors 500", func(t *testing.T) {
+		c, _ := newEchoCtx("Bearer " + APIKeyPrefix + "abc123")
+		if code := httpCode(RequireAuthDual(a, disabledIAM)(pass)(c)); code != http.StatusInternalServerError {
+			t.Errorf("got %d want 500", code)
+		}
+	})
+
+	t.Run("API key with wrong store type is unauthorized", func(t *testing.T) {
+		c, _ := newEchoCtx("Bearer " + APIKeyPrefix + "abc123")
+		c.Set("store", "not-a-store")
+		if code := httpCode(RequireAuthDual(a, disabledIAM)(pass)(c)); code != http.StatusUnauthorized {
+			t.Errorf("got %d want 401", code)
+		}
+	})
+
+	t.Run("IAM request rejected when IAM disabled", func(t *testing.T) {
+		c, _ := newEchoCtx("AWS4-HMAC-SHA256 Credential=...")
+		if code := httpCode(RequireAuthDual(a, disabledIAM)(pass)(c)); code != http.StatusUnauthorized {
+			t.Errorf("got %d want 401", code)
+		}
+	})
+}

--- a/internal/k8s/serviceaccount.go
+++ b/internal/k8s/serviceaccount.go
@@ -14,9 +14,13 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 )
 
-// ServiceAccountManager manages Kubernetes ServiceAccounts for cluster pool leasing
+// ServiceAccountManager manages Kubernetes ServiceAccounts for cluster pool leasing.
+//
+// clientset is held as the kubernetes.Interface rather than the concrete
+// *kubernetes.Clientset so tests can inject a fake clientset; production wiring
+// via NewServiceAccountManager is unchanged (*Clientset satisfies the interface).
 type ServiceAccountManager struct {
-	clientset *kubernetes.Clientset
+	clientset kubernetes.Interface
 }
 
 // PoolLeaseCredentials contains ServiceAccount credentials for pool cluster leasing

--- a/internal/k8s/serviceaccount_test.go
+++ b/internal/k8s/serviceaccount_test.go
@@ -1,0 +1,155 @@
+package k8s
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	authv1 "k8s.io/api/authentication/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
+)
+
+// tokenReactor makes the fake CreateToken subresource return a fixed token.
+func tokenReactor(token string) k8stesting.ReactionFunc {
+	return func(action k8stesting.Action) (bool, runtime.Object, error) {
+		if action.GetSubresource() != "token" {
+			return false, nil, nil // not the token subresource; let the tracker handle it
+		}
+		return true, &authv1.TokenRequest{Status: authv1.TokenRequestStatus{Token: token}}, nil
+	}
+}
+
+func saExists(t *testing.T, cs *fake.Clientset, name string) bool {
+	t.Helper()
+	_, err := cs.CoreV1().ServiceAccounts("default").Get(context.Background(), name, metav1.GetOptions{})
+	if err != nil && !apierrors.IsNotFound(err) {
+		t.Fatalf("unexpected get error: %v", err)
+	}
+	return err == nil
+}
+
+func crbExists(t *testing.T, cs *fake.Clientset, name string) bool {
+	t.Helper()
+	_, err := cs.RbacV1().ClusterRoleBindings().Get(context.Background(), name, metav1.GetOptions{})
+	if err != nil && !apierrors.IsNotFound(err) {
+		t.Fatalf("unexpected get error: %v", err)
+	}
+	return err == nil
+}
+
+func TestCreatePoolLeaseServiceAccount_Success(t *testing.T) {
+	cs := fake.NewSimpleClientset()
+	cs.PrependReactor("create", "serviceaccounts", tokenReactor("tok-abc"))
+	m := &ServiceAccountManager{clientset: cs}
+
+	creds, err := m.CreatePoolLeaseServiceAccount(context.Background(), "web", 8)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if creds.SAName != "ocpctl-lease-web" || creds.SANamespace != "default" {
+		t.Errorf("unexpected SA identity: %+v", creds)
+	}
+	if creds.Token != "tok-abc" {
+		t.Errorf("token = %q, want tok-abc", creds.Token)
+	}
+	if creds.TokenExpiresAt.IsZero() {
+		t.Error("expected non-zero token expiry")
+	}
+	if !saExists(t, cs, "ocpctl-lease-web") {
+		t.Error("expected ServiceAccount to exist")
+	}
+	if !crbExists(t, cs, "ocpctl-lease-web-admin") {
+		t.Error("expected ClusterRoleBinding to exist")
+	}
+}
+
+func TestCreatePoolLeaseServiceAccount_SACreateFails(t *testing.T) {
+	cs := fake.NewSimpleClientset()
+	cs.PrependReactor("create", "serviceaccounts", func(a k8stesting.Action) (bool, runtime.Object, error) {
+		if a.GetSubresource() == "" { // the SA itself, not the token subresource
+			return true, nil, fmt.Errorf("sa boom")
+		}
+		return false, nil, nil
+	})
+	m := &ServiceAccountManager{clientset: cs}
+
+	if _, err := m.CreatePoolLeaseServiceAccount(context.Background(), "web", 8); err == nil {
+		t.Fatal("expected error when SA creation fails")
+	}
+}
+
+func TestCreatePoolLeaseServiceAccount_CRBFailsCleansUpSA(t *testing.T) {
+	cs := fake.NewSimpleClientset()
+	cs.PrependReactor("create", "clusterrolebindings", func(a k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, fmt.Errorf("crb boom")
+	})
+	m := &ServiceAccountManager{clientset: cs}
+
+	if _, err := m.CreatePoolLeaseServiceAccount(context.Background(), "web", 8); err == nil {
+		t.Fatal("expected error when CRB creation fails")
+	}
+	if saExists(t, cs, "ocpctl-lease-web") {
+		t.Error("expected ServiceAccount to be cleaned up after CRB failure")
+	}
+}
+
+func TestCreatePoolLeaseServiceAccount_TokenFailsCleansUpAll(t *testing.T) {
+	cs := fake.NewSimpleClientset()
+	cs.PrependReactor("create", "serviceaccounts", func(a k8stesting.Action) (bool, runtime.Object, error) {
+		if a.GetSubresource() == "token" {
+			return true, nil, fmt.Errorf("token boom")
+		}
+		return false, nil, nil
+	})
+	m := &ServiceAccountManager{clientset: cs}
+
+	if _, err := m.CreatePoolLeaseServiceAccount(context.Background(), "web", 8); err == nil {
+		t.Fatal("expected error when token creation fails")
+	}
+	if saExists(t, cs, "ocpctl-lease-web") {
+		t.Error("expected ServiceAccount cleaned up after token failure")
+	}
+	if crbExists(t, cs, "ocpctl-lease-web-admin") {
+		t.Error("expected ClusterRoleBinding cleaned up after token failure")
+	}
+}
+
+func TestDeletePoolLeaseServiceAccount(t *testing.T) {
+	cs := fake.NewSimpleClientset()
+	cs.PrependReactor("create", "serviceaccounts", tokenReactor("tok-abc"))
+	m := &ServiceAccountManager{clientset: cs}
+
+	if _, err := m.CreatePoolLeaseServiceAccount(context.Background(), "web", 8); err != nil {
+		t.Fatalf("setup create failed: %v", err)
+	}
+
+	if err := m.DeletePoolLeaseServiceAccount(context.Background(), "web"); err != nil {
+		t.Fatalf("delete failed: %v", err)
+	}
+	if saExists(t, cs, "ocpctl-lease-web") {
+		t.Error("expected ServiceAccount removed")
+	}
+	if crbExists(t, cs, "ocpctl-lease-web-admin") {
+		t.Error("expected ClusterRoleBinding removed")
+	}
+}
+
+func TestNewServiceAccountManager_BadKubeconfig(t *testing.T) {
+	if _, err := NewServiceAccountManager(filepath.Join(t.TempDir(), "does-not-exist")); err == nil {
+		t.Error("expected error for missing kubeconfig")
+	}
+}
+
+func TestDeletePoolLeaseServiceAccount_NotFoundTolerated(t *testing.T) {
+	cs := fake.NewSimpleClientset()
+	m := &ServiceAccountManager{clientset: cs}
+	// Nothing exists; NotFound must be swallowed and return nil.
+	if err := m.DeletePoolLeaseServiceAccount(context.Background(), "ghost"); err != nil {
+		t.Errorf("expected nil error for missing resources, got %v", err)
+	}
+}

--- a/internal/poolscheduler/scheduler_test.go
+++ b/internal/poolscheduler/scheduler_test.go
@@ -1,0 +1,47 @@
+package poolscheduler
+
+import (
+	"testing"
+	"time"
+)
+
+func TestDefaultConfig(t *testing.T) {
+	cfg := DefaultConfig()
+	if cfg.CheckInterval != 2*time.Minute {
+		t.Errorf("CheckInterval = %v, want 2m", cfg.CheckInterval)
+	}
+	if cfg.LeaseCheckInterval != time.Minute {
+		t.Errorf("LeaseCheckInterval = %v, want 1m", cfg.LeaseCheckInterval)
+	}
+	if !cfg.RefreshCheckEnabled {
+		t.Error("RefreshCheckEnabled should default to true")
+	}
+}
+
+func TestNewSchedulerDefaultsConfig(t *testing.T) {
+	// A nil config falls back to DefaultConfig.
+	s := NewScheduler(nil, nil)
+	if s.config == nil || s.config.CheckInterval != 2*time.Minute {
+		t.Errorf("expected default config, got %+v", s.config)
+	}
+	if s.running {
+		t.Error("scheduler should not be running before Start")
+	}
+}
+
+func TestNewSchedulerCustomConfig(t *testing.T) {
+	cfg := &Config{CheckInterval: 30 * time.Second, LeaseCheckInterval: 10 * time.Second}
+	s := NewScheduler(cfg, nil)
+	if s.config.CheckInterval != 30*time.Second {
+		t.Errorf("CheckInterval = %v, want 30s", s.config.CheckInterval)
+	}
+}
+
+func TestStopBeforeStartIsSafe(t *testing.T) {
+	// Stop with a nil cancel func must not panic.
+	s := NewScheduler(nil, nil)
+	s.Stop()
+	if s.running {
+		t.Error("running should be false after Stop")
+	}
+}

--- a/internal/s3/client_test.go
+++ b/internal/s3/client_test.go
@@ -1,0 +1,48 @@
+package s3
+
+import "testing"
+
+func TestParseS3URI(t *testing.T) {
+	tests := []struct {
+		name       string
+		uri        string
+		wantBucket string
+		wantKey    string
+		wantErr    bool
+	}{
+		{"valid", "s3://my-bucket/path/to/object.txt", "my-bucket", "path/to/object.txt", false},
+		{"valid single-segment key", "s3://bucket/key", "bucket", "key", false},
+		{"missing scheme", "my-bucket/key", "", "", true},
+		{"missing key", "s3://bucket-only", "", "", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			bucket, key, err := parseS3URI(tt.uri)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("err = %v, wantErr %v", err, tt.wantErr)
+			}
+			if err != nil {
+				return
+			}
+			if bucket != tt.wantBucket || key != tt.wantKey {
+				t.Errorf("got (%q, %q), want (%q, %q)", bucket, key, tt.wantBucket, tt.wantKey)
+			}
+		})
+	}
+}
+
+func TestParseS3URIExportedWrapper(t *testing.T) {
+	bucket, key, err := ParseS3URI("s3://b/k")
+	if err != nil || bucket != "b" || key != "k" {
+		t.Errorf("ParseS3URI = (%q, %q, %v)", bucket, key, err)
+	}
+}
+
+func TestGetObjectURL(t *testing.T) {
+	c := &Client{region: "us-west-2"}
+	got := c.GetObjectURL("my-bucket", "dir/file name.txt")
+	want := "https://my-bucket.s3.us-west-2.amazonaws.com/dir%2Ffile%20name.txt"
+	if got != want {
+		t.Errorf("GetObjectURL = %q, want %q", got, want)
+	}
+}

--- a/scripts/check-coverage.sh
+++ b/scripts/check-coverage.sh
@@ -23,7 +23,12 @@ set -euo pipefail
 cd "$(dirname "$0")/.."
 
 # pkg:floor (minimum statement coverage %, integer).
-# PR3 will add: internal/api/middleware, internal/poolscheduler, internal/auth (full)
+#
+# NOTE on internal/s3 and internal/poolscheduler: these are integration-shaped.
+# s3 wraps the AWS S3 client (presign/get/put) and poolscheduler runs raw
+# pgx.Rows SQL against the pool DB, so only their pure surface (S3 URI parsing,
+# config/constructor logic) is unit-testable today. Their floors gate that
+# surface against regression; raising them needs an S3-API / query-Rows seam.
 #
 # NOTE on internal/janitor: a store-interface seam (stores.go) now makes the
 # DB-driven safety/cleanup logic unit-testable, and janitor.go (the TTL reaper,
@@ -39,6 +44,11 @@ FLOORS=(
   "internal/secrets:65"
   "internal/aws/cleanup:70"
   "internal/janitor:28"
+  "internal/api/middleware:80"
+  "internal/auth:55"
+  "internal/k8s:75"
+  "internal/s3:15"
+  "internal/poolscheduler:3"
 )
 
 profile="$(mktemp)"


### PR DESCRIPTION
## Summary

PR3 of the #102 risk-first coverage work — backfills unit tests with
per-package CI floors for the middleware/auth/k8s/s3/poolscheduler tier. Follows
#106 (floors), #107 (cleanup/janitor helpers), #108 (janitor store seam).

Packages split by testability:

### Fully unit-testable (Echo httptest / fakes)
| Package | Before | After | Floor |
|---|---|---|---|
| `internal/api/middleware` | 0% | 86.1% | 80 |
| `internal/auth` | 21.1% | 62.5% | 55 |
| `internal/k8s` | 0% | 83.8% | 75 |

- **middleware** — cache-control headers, per-IP rate limiters + burst
  throttling + custom messages, prometheus (record path, `/metrics` skip,
  status normalization), logger.
- **auth** — `RequireAuth`/`RequireRole`/`RequireAdmin`/`RequireTeamAdmin`/
  `OptionalAuth`, every context getter (`GetUser`/`ID`/`Role`, `IsAdmin`,
  `CanManageTeam`), `RequireAuthDual` (JWT + API-key-format + IAM-disabled
  branches), API-key format guards, `IsIAMRequest`, disabled-IAM authenticator.
  The remaining gap is the AWS-STS/store-bound IAM validation and the API-key
  DB lookup — those need a store/AWS seam.
- **k8s** — pool-lease ServiceAccount create/delete against a fake clientset,
  including the **CRB-fails** and **token-fails** cleanup paths and the
  NotFound-tolerant delete.

### Integration-shaped (pure surface only — honest low floors, documented)
| Package | Before | After | Floor |
|---|---|---|---|
| `internal/s3` | 0% | 18.9% | 15 |
| `internal/poolscheduler` | 0% | 3.8% | 3 |

- **s3** wraps the AWS S3 client (presign/get/put); only URI parsing +
  object-URL formatting are pure.
- **poolscheduler** runs raw `pgx.Rows` SQL against the pool DB; only
  config/constructor/`Stop` are testable. Both need a seam (S3-API / query-Rows)
  to go higher; the `check-coverage.sh` NOTE records this.

## Production change
`ServiceAccountManager.clientset` is now typed `kubernetes.Interface` instead of
`*kubernetes.Clientset` so a fake clientset can be injected. Wiring via
`NewServiceAccountManager` is unchanged (`*Clientset` satisfies the interface).
`go.mod`/`go.sum` gain two indirect **test-only** deps pulled in by client-go's
fake testing package.

## Test plan
- `./scripts/check-coverage.sh` — all nine package floors pass
- `go build ./...` and `go vet` on the touched packages are clean