### PR TITLE
Fix data race between janitor Start and Stop

### DIFF
--- a/internal/janitor/janitor.go
+++ b/internal/janitor/janitor.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/google/uuid"
@@ -45,9 +46,12 @@ func DefaultConfig() *Config {
 
 // Janitor performs periodic cleanup tasks
 type Janitor struct {
-	config           *Config
-	stores           janitorStores
-	workDir          string
+	config  *Config
+	stores  janitorStores
+	workDir string
+	// mu guards the running/ctx/cancel handoff between Start (runs in its own
+	// goroutine) and Stop (called from the shutdown path on another goroutine).
+	mu               sync.Mutex
 	running          bool
 	ctx              context.Context
 	cancel           context.CancelFunc
@@ -78,8 +82,11 @@ func NewJanitor(config *Config, st *store.Store, workDir string) *Janitor {
 
 // Start starts the janitor loop
 func (j *Janitor) Start(ctx context.Context) error {
+	j.mu.Lock()
 	j.ctx, j.cancel = context.WithCancel(ctx)
 	j.running = true
+	jctx := j.ctx
+	j.mu.Unlock()
 
 	log.Printf("Janitor starting (check_interval=%s)", j.config.CheckInterval)
 
@@ -92,9 +99,9 @@ func (j *Janitor) Start(ctx context.Context) error {
 
 	for {
 		select {
-		case <-j.ctx.Done():
+		case <-jctx.Done():
 			log.Printf("Janitor shutting down")
-			return j.ctx.Err()
+			return jctx.Err()
 
 		case <-ticker.C:
 			j.run()
@@ -104,10 +111,14 @@ func (j *Janitor) Start(ctx context.Context) error {
 
 // Stop stops the janitor gracefully
 func (j *Janitor) Stop() {
-	if j.cancel != nil {
-		j.cancel()
-	}
+	j.mu.Lock()
+	cancel := j.cancel
 	j.running = false
+	j.mu.Unlock()
+
+	if cancel != nil {
+		cancel()
+	}
 }
 
 // run performs all cleanup tasks


### PR DESCRIPTION
## Problem
`Janitor.Start()` runs in its own goroutine (see `cmd/worker/main.go`) and writes `ctx`/`cancel`/`running`, while `Stop()` reads `cancel` and writes `running` from the shutdown path on another goroutine — with no synchronization. This is a real production data race.

`go test -race` in the deploy pipeline flagged it via `TestStartStop` (added in #109):

```
WARNING: DATA RACE
Read at ... by goroutine 65:
  janitor.(*Janitor).Stop()  janitor.go:107
Previous write at ... by goroutine 66:
  janitor.(*Janitor).Start() janitor.go:81
```

CI already runs `-race`, but the detection is timing-sensitive and didn't trip on the runner for #109.

## Fix
- Add a `sync.Mutex` to `Janitor` guarding the `running`/`ctx`/`cancel` handoff.
- `Start()` sets the fields under the lock and captures the context into a local (`jctx`) for the run loop, so the loop never reads a field another goroutine may touch.
- `Stop()` reads `cancel` and clears `running` under the lock, then cancels outside it.

No behavior change; the janitor still runs an immediate pass, loops on the ticker, and stops on cancellation.

## Test
`go test -race ./internal/janitor/` passes (previously failed on `TestStartStop`).