### PR TITLE
Fix kubeadmin console credentials for OpenShift IPI clusters (#111)

### DIFF
--- a/internal/api/handler_cluster_outputs.go
+++ b/internal/api/handler_cluster_outputs.go
@@ -212,28 +212,44 @@ func (h *ClusterHandler) GetOutputs(c echo.Context) error {
 		LogInfo(c, "no kubeconfig URI in outputs")
 	}
 
-	// Read kubeadmin password from disk if path is available
+	// Populate the kubeadmin credentials from KubeadminSecretRef, which is
+	// overloaded by cluster type:
+	//   - OpenShift IPI: an s3:// URI to the uploaded kubeadmin-password artifact
+	//     (legacy clusters may still carry a worker-local file:// path).
+	//   - ROSA/ARO: an inline "user:pass" string (handled by the frontend, not here).
+	// Only the file:// / s3:// forms name a password we can resolve into the
+	// structured Kubeadmin field; inline "user:pass" refs are left for the client.
 	if outputs.KubeadminSecretRef != nil && *outputs.KubeadminSecretRef != "" {
-		// Extract file path from file:// URI
-		passwordPath := *outputs.KubeadminSecretRef
-		if strings.HasPrefix(passwordPath, "file://") {
-			passwordPath = passwordPath[7:] // Remove "file://" prefix
-		}
-
-		// Validate path to prevent path traversal attacks
-		validatedPath, err := validateOutputFilePath(passwordPath)
-		if err != nil {
-			LogInfo(c, "invalid kubeadmin password path blocked", "error", err.Error(), "attempted_path", passwordPath)
-		} else {
-			LogInfo(c, "reading kubeadmin password", "path", validatedPath)
-			if passwordData, err := os.ReadFile(validatedPath); err == nil {
+		ref := *outputs.KubeadminSecretRef
+		switch {
+		case strings.HasPrefix(ref, "s3://"):
+			bucket, key, err := s3.ParseS3URI(ref)
+			if err != nil {
+				LogInfo(c, "invalid kubeadmin s3 uri", "error", err.Error(), "uri", ref)
+			} else if passwordData, err := s3.DownloadFile(ctx, bucket, key); err != nil {
+				LogInfo(c, "failed to download kubeadmin password from s3", "error", err.Error(), "uri", ref)
+			} else {
 				response.Kubeadmin = &KubeadminCredentials{
 					Username: "kubeadmin",
-					Password: string(passwordData),
+					Password: strings.TrimSpace(string(passwordData)),
+				}
+				LogInfo(c, "kubeadmin password read from s3")
+			}
+		case strings.HasPrefix(ref, "file://") || strings.HasPrefix(ref, "/"):
+			// Legacy worker-local path (only resolvable when the API and the
+			// worker that created the cluster share a host).
+			passwordPath := strings.TrimPrefix(ref, "file://")
+			validatedPath, err := validateOutputFilePath(passwordPath)
+			if err != nil {
+				LogInfo(c, "invalid kubeadmin password path blocked", "error", err.Error(), "attempted_path", passwordPath)
+			} else if passwordData, err := os.ReadFile(validatedPath); err != nil {
+				LogInfo(c, "failed to read kubeadmin password", "error", err.Error(), "path", validatedPath)
+			} else {
+				response.Kubeadmin = &KubeadminCredentials{
+					Username: "kubeadmin",
+					Password: strings.TrimSpace(string(passwordData)),
 				}
 				LogInfo(c, "kubeadmin password read successfully")
-			} else {
-				LogInfo(c, "failed to read kubeadmin password", "error", err.Error(), "path", validatedPath)
 			}
 		}
 	}

--- a/internal/api/handler_pool_lease.go
+++ b/internal/api/handler_pool_lease.go
@@ -8,6 +8,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/labstack/echo/v4"
 	"github.com/tsanders-rh/ocpctl/internal/auth"
+	"github.com/tsanders-rh/ocpctl/internal/s3"
 	"github.com/tsanders-rh/ocpctl/internal/store"
 	"github.com/tsanders-rh/ocpctl/pkg/types"
 )
@@ -119,29 +120,41 @@ func (h *PoolLeaseHandler) LeaseCluster(c echo.Context) error {
 			response.OcLoginCommand = *outputs.OcLoginCommand
 		}
 
-		// Add kubeadmin credentials for web console login
+		// Add kubeadmin credentials for web console login. KubeadminSecretRef is
+		// an s3:// URI for OpenShift IPI clusters (legacy clusters may carry a
+		// worker-local file:// path); resolve either into the password.
 		if outputs.KubeadminSecretRef != nil && *outputs.KubeadminSecretRef != "" {
-			passwordPath := *outputs.KubeadminSecretRef
-			if strings.HasPrefix(passwordPath, "file://") {
-				passwordPath = passwordPath[7:] // Remove "file://" prefix
+			ref := *outputs.KubeadminSecretRef
+			setKubeadmin := func(password string) {
+				response.Kubeadmin = &struct {
+					Username string `json:"username"`
+					Password string `json:"password"`
+				}{
+					Username: "kubeadmin",
+					Password: strings.TrimSpace(password),
+				}
 			}
-
-			// Validate path to prevent path traversal attacks
-			validatedPath, err := validateOutputFilePath(passwordPath)
-			if err != nil {
-				LogWarning(c, "invalid kubeadmin password path blocked", "error", err.Error(), "attempted_path", passwordPath)
-			} else {
-				if passwordData, err := os.ReadFile(validatedPath); err == nil {
-					response.Kubeadmin = &struct {
-						Username string `json:"username"`
-						Password string `json:"password"`
-					}{
-						Username: "kubeadmin",
-						Password: string(passwordData),
-					}
-					LogInfo(c, "kubeadmin password included in lease response")
+			switch {
+			case strings.HasPrefix(ref, "s3://"):
+				bucket, key, err := s3.ParseS3URI(ref)
+				if err != nil {
+					LogWarning(c, "invalid kubeadmin s3 uri", "error", err.Error(), "uri", ref)
+				} else if passwordData, err := s3.DownloadFile(ctx, bucket, key); err != nil {
+					LogWarning(c, "failed to download kubeadmin password from s3", "error", err.Error(), "uri", ref)
 				} else {
+					setKubeadmin(string(passwordData))
+					LogInfo(c, "kubeadmin password included in lease response")
+				}
+			case strings.HasPrefix(ref, "file://") || strings.HasPrefix(ref, "/"):
+				passwordPath := strings.TrimPrefix(ref, "file://")
+				validatedPath, err := validateOutputFilePath(passwordPath)
+				if err != nil {
+					LogWarning(c, "invalid kubeadmin password path blocked", "error", err.Error(), "attempted_path", passwordPath)
+				} else if passwordData, err := os.ReadFile(validatedPath); err != nil {
 					LogWarning(c, "failed to read kubeadmin password", "error", err.Error(), "path", validatedPath)
+				} else {
+					setKubeadmin(string(passwordData))
+					LogInfo(c, "kubeadmin password included in lease response")
 				}
 			}
 		}

--- a/internal/worker/handler_create.go
+++ b/internal/worker/handler_create.go
@@ -581,6 +581,18 @@ func (h *CreateHandler) updateArtifactURIs(ctx context.Context, clusterID string
 	metadataS3URI := fmt.Sprintf("s3://%s/clusters/%s/artifacts/metadata.json", h.config.S3BucketName, clusterID)
 	outputs.MetadataS3URI = &metadataS3URI
 
+	// Rewrite the kubeadmin secret ref to its S3 location, mirroring the
+	// kubeconfig/metadata rewrites above. This is guarded to only touch a
+	// worker-local file:// path: OpenShift IPI sets KubeadminSecretRef to
+	// file://<workDir>/auth/kubeadmin-password, which is unreadable from the API
+	// host once the worker's work dir is gone (or when worker and API run on
+	// separate hosts). ROSA/ARO instead store an inline "user:pass" value that
+	// must NOT be clobbered, so leave anything that isn't a file:// ref alone.
+	if outputs.KubeadminSecretRef != nil && strings.HasPrefix(*outputs.KubeadminSecretRef, "file://") {
+		kubeadminS3URI := fmt.Sprintf("s3://%s/clusters/%s/artifacts/auth/kubeadmin-password", h.config.S3BucketName, clusterID)
+		outputs.KubeadminSecretRef = &kubeadminS3URI
+	}
+
 	// Update in database
 	if err := h.store.ClusterOutputs.Update(ctx, outputs); err != nil {
 		return fmt.Errorf("update cluster outputs: %w", err)

--- a/internal/worker/handler_pool_clean.go
+++ b/internal/worker/handler_pool_clean.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/tsanders-rh/ocpctl/internal/k8s"
+	"github.com/tsanders-rh/ocpctl/internal/s3"
 	"github.com/tsanders-rh/ocpctl/internal/store"
 	"github.com/tsanders-rh/ocpctl/pkg/types"
 	"golang.org/x/crypto/bcrypt"
@@ -378,19 +379,32 @@ func (h *PoolCleanHandler) rotateKubeadminPassword(ctx context.Context, cluster 
 
 	log.Printf("Updated kubeadmin secret in cluster %s", cluster.Name)
 
-	// Update the kubeadmin-password file on disk if it exists
+	// Persist the new password to wherever KubeadminSecretRef points so the API
+	// (which reads it back to display console credentials) doesn't serve a stale
+	// value. For OpenShift IPI this is now an s3:// URI; legacy clusters may still
+	// carry a worker-local file:// path. A failure here is non-fatal: the
+	// in-cluster secret is already rotated.
 	if outputs.KubeadminSecretRef != nil && *outputs.KubeadminSecretRef != "" {
-		passwordPath := *outputs.KubeadminSecretRef
-		if strings.HasPrefix(passwordPath, "file://") {
-			passwordPath = passwordPath[7:] // Remove "file://" prefix
-		}
-
-		// Write new password to file
-		if err := os.WriteFile(passwordPath, []byte(newPassword), 0600); err != nil {
-			log.Printf("Warning: Failed to update kubeadmin-password file: %v", err)
-			// Don't fail the rotation if file update fails - the secret is updated
-		} else {
-			log.Printf("Updated kubeadmin-password file at %s", passwordPath)
+		ref := *outputs.KubeadminSecretRef
+		switch {
+		case strings.HasPrefix(ref, "s3://"):
+			bucket, key, err := s3.ParseS3URI(ref)
+			if err != nil {
+				log.Printf("Warning: invalid kubeadmin s3 uri %q: %v", ref, err)
+			} else if client, err := s3.NewClient(ctx); err != nil {
+				log.Printf("Warning: failed to create s3 client for kubeadmin update: %v", err)
+			} else if err := client.UploadFile(ctx, bucket, key, []byte(newPassword)); err != nil {
+				log.Printf("Warning: failed to update kubeadmin-password in s3: %v", err)
+			} else {
+				log.Printf("Updated kubeadmin-password in s3 at %s", ref)
+			}
+		case strings.HasPrefix(ref, "file://") || strings.HasPrefix(ref, "/"):
+			passwordPath := strings.TrimPrefix(ref, "file://")
+			if err := os.WriteFile(passwordPath, []byte(newPassword), 0600); err != nil {
+				log.Printf("Warning: Failed to update kubeadmin-password file: %v", err)
+			} else {
+				log.Printf("Updated kubeadmin-password file at %s", passwordPath)
+			}
 		}
 	}
 

--- a/web/app/(dashboard)/clusters/[id]/page.tsx
+++ b/web/app/(dashboard)/clusters/[id]/page.tsx
@@ -696,8 +696,14 @@ export default function ClusterDetailPage() {
               </div>
             )}
 
-            {/* Admin credentials - show for non-pool clusters, admins, or current leasee */}
-            {outputs.kubeadmin_secret_ref && (
+            {/* Admin credentials - show for non-pool clusters, admins, or current leasee.
+                Only render for inline "user:pass" refs (ROSA/ARO). For OpenShift IPI,
+                kubeadmin_secret_ref is a storage URI (s3://, file://, or an arn:) that
+                is NOT a credential — splitting it on ':' would show "s3"/"file" as the
+                username. Those clusters surface creds via the Kubeadmin Credentials
+                block below (outputs.kubeadmin), populated from the stored password. */}
+            {outputs.kubeadmin_secret_ref &&
+              !/^(file|s3|arn):/.test(outputs.kubeadmin_secret_ref) && (
               !cluster.pool_id || // Not a pool cluster - show to everyone
               user?.role === UserRole.ADMIN || // Admin - show always
               (cluster.pool_id && cluster.leased_by === user?.email) // Pool cluster and current user is leasee


### PR DESCRIPTION
## Problem

The cluster detail page showed **`file`** as the Console Credentials username (and no usable password) for OpenShift IPI clusters — see #111.

**Root cause:** OpenShift IPI sets `KubeadminSecretRef` to a worker-local `file://<workDir>/auth/kubeadmin-password` path, but `updateArtifactURIs` only rewrote the kubeconfig/metadata refs to S3 — it never rewrote the kubeadmin ref. On a co-located dev host the API can still read that on-disk file, so the Kubeadmin panel worked *by accident*; in production the worker is a separate (autoscaled) host, so the file is unreadable on the API host. The panel came up empty and the UI fell back to splitting the raw `file://...` string on `:`, rendering `file` as the username.

> Note: this is why dev only *appeared* fine — host co-location masked the bug. It is not reproducible against a co-located worker.

## Fix

**Backend**
- `updateArtifactURIs` now rewrites `KubeadminSecretRef` to its `s3://` artifact location, mirroring the existing kubeconfig/metadata rewrites. Guarded to only touch `file://` refs, so ROSA/ARO inline `user:pass` values are left intact.
- `GetOutputs` and the pool-lease handler resolve the password from `s3://` (and still from legacy `file://` paths) to populate the structured `kubeadmin` field.
- Pool-clean rotation re-uploads the rotated password to S3 (or writes the legacy file) so the API never serves a stale password.

**Frontend**
- The "Console Credentials" (user:pass split) block only renders for genuine inline refs; URI-style refs (`file://`, `s3://`, `arn:`) no longer show `s3`/`file` as a username. IPI clusters surface creds via the existing "Kubeadmin Credentials" block (`outputs.kubeadmin`).

## Testing
- `go build ./...`, `go vet`, and `go test ./internal/api/... ./internal/worker/...` pass.
- `tsc --noEmit` clean.

Closes #111