### PR TITLE
Clean up kubeconfig download UX (hint text + filename)

### DIFF
--- a/internal/api/handler_cluster_outputs.go
+++ b/internal/api/handler_cluster_outputs.go
@@ -353,7 +353,7 @@ func (h *ClusterHandler) DownloadKubeconfig(c echo.Context) error {
 	}
 
 	// Set headers for file download
-	filename := fmt.Sprintf("kubeconfig-%s.yaml", cluster.Name)
+	filename := fmt.Sprintf("kubeconfig-%s", cluster.Name)
 	c.Response().Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=%s", filename))
 	c.Response().Header().Set("Content-Type", "application/x-yaml")
 
@@ -513,7 +513,7 @@ func (h *ClusterHandler) GetKubeconfigDownloadURL(c echo.Context) error {
 		return SuccessOK(c, map[string]interface{}{
 			"download_url": directDownloadURL,
 			"expires_in":   "session-based",
-			"filename":     fmt.Sprintf("kubeconfig-%s.yaml", cluster.Name),
+			"filename":     fmt.Sprintf("kubeconfig-%s", cluster.Name),
 			"storage_type": "local",
 		})
 	}
@@ -526,7 +526,7 @@ func (h *ClusterHandler) GetKubeconfigDownloadURL(c echo.Context) error {
 
 	// Generate presigned URL (valid for 15 minutes), forcing a cluster-specific
 	// download filename so multiple kubeconfigs can be told apart.
-	downloadFilename := fmt.Sprintf("kubeconfig-%s.yaml", cluster.Name)
+	downloadFilename := fmt.Sprintf("kubeconfig-%s", cluster.Name)
 	presignedURL, err := s3Client.GeneratePresignedDownloadURL(ctx, kubeconfigURI, 15, downloadFilename)
 	if err != nil {
 		return LogAndReturnGenericError(c, fmt.Errorf("failed to generate presigned URL: %w", err))
@@ -567,7 +567,7 @@ func (h *ClusterHandler) GetKubeconfigDownloadURL(c echo.Context) error {
 	return SuccessOK(c, map[string]interface{}{
 		"download_url": presignedURL,
 		"expires_in":   "15 minutes",
-		"filename":     fmt.Sprintf("kubeconfig-%s.yaml", cluster.Name),
+		"filename":     fmt.Sprintf("kubeconfig-%s", cluster.Name),
 		"storage_type": "s3",
 	})
 }

--- a/web/app/(dashboard)/clusters/[id]/page.tsx
+++ b/web/app/(dashboard)/clusters/[id]/page.tsx
@@ -887,9 +887,7 @@ export default function ClusterDetailPage() {
                   </Button>
                 </div>
                 <p className="text-xs text-muted-foreground">
-                  {outputs.kubeconfig_s3_uri?.startsWith('s3://')
-                    ? `S3 URI - Use AWS CLI to download: aws s3 cp ${outputs.kubeconfig_s3_uri} ./kubeconfig`
-                    : `Local storage - Use download button above or access via API`}
+                  Click the download button to save the kubeconfig, or copy the URI for API access.
                 </p>
               </div>
             )}

--- a/web/app/(dashboard)/clusters/[id]/page.tsx
+++ b/web/app/(dashboard)/clusters/[id]/page.tsx
@@ -863,7 +863,7 @@ export default function ClusterDetailPage() {
                           const url = window.URL.createObjectURL(blob);
                           const link = document.createElement('a');
                           link.href = url;
-                          link.download = data.filename || `kubeconfig-${cluster.name}.yaml`;
+                          link.download = data.filename || `kubeconfig-${cluster.name}`;
                           document.body.appendChild(link);
                           link.click();
                           document.body.removeChild(link);
@@ -872,7 +872,7 @@ export default function ClusterDetailPage() {
                           // For S3, use presigned URL directly (no auth needed)
                           const link = document.createElement('a');
                           link.href = data.download_url;
-                          link.download = data.filename || `kubeconfig-${cluster.name}.yaml`;
+                          link.download = data.filename || `kubeconfig-${cluster.name}`;
                           document.body.appendChild(link);
                           link.click();
                           document.body.removeChild(link);


### PR DESCRIPTION
Two small cluster-detail-page cleanups around kubeconfig download.

## 1. Misleading download hint

The Kubeconfig field's helper text told users to download via the AWS CLI:

> S3 URI - Use AWS CLI to download: `aws s3 cp s3://ocpctl-binaries/clusters/<id>/artifacts/auth/kubeconfig ./kubeconfig`

This is misleading:
- The **download button** next to the field already works — it fetches a presigned URL from `/api/v1/clusters/{id}/kubeconfig/download-url` and downloads directly (no AWS CLI; handles both S3 and local storage).
- `aws s3 cp` requires AWS credentials for the internal `ocpctl-binaries` bucket, which end users leasing clusters don't have — so the command fails for them.
- It leaked the internal bucket name/layout into user-facing copy.

Replaced with a single storage-agnostic hint pointing at the download button.

_Note:_ the `aws s3 cp` examples in `docs/page.tsx` are intentionally left — those are CI/CD snippets where the runner has credentials.

## 2. Kubeconfig filename `.yaml` → no extension

Kubeconfig files conventionally have no extension. The download was named `kubeconfig-<name>.yaml`; renamed to `kubeconfig-<name>` in both the API (`Content-Disposition` + presigned response filename) and the frontend fallback. Content is unchanged and works regardless of name.

`go build` and `tsc --noEmit` clean.