### PR TITLE
Add adhoc usage report with cost estimation and PDF export

### DIFF
--- a/internal/api/handler_reports.go
+++ b/internal/api/handler_reports.go
@@ -1,0 +1,278 @@
+package api
+
+import (
+	"sort"
+	"time"
+
+	"github.com/labstack/echo/v4"
+	"github.com/tsanders-rh/ocpctl/internal/cost"
+	"github.com/tsanders-rh/ocpctl/internal/profile"
+	"github.com/tsanders-rh/ocpctl/internal/store"
+	"github.com/tsanders-rh/ocpctl/pkg/types"
+)
+
+// dateFormat is the query-param date layout for report ranges.
+const dateFormat = "2006-01-02"
+
+// ReportHandler serves platform-wide usage/cost reports (admin only).
+type ReportHandler struct {
+	store    *store.Store
+	registry *profile.Registry
+}
+
+// NewReportHandler creates a new report handler.
+func NewReportHandler(st *store.Store, r *profile.Registry) *ReportHandler {
+	return &ReportHandler{store: st, registry: r}
+}
+
+// GetUsageReport returns an adhoc, date-ranged usage report.
+//
+//	@Summary		Get usage report
+//	@Description	Returns a platform-wide usage/cost report for an adhoc date range: estimated cost, most used profiles, most active users, and cluster lifecycle stats.
+//	@Tags			Reports
+//	@Accept			json
+//	@Produce		json
+//	@Param			start_date	query		string	false	"Start date (YYYY-MM-DD), inclusive. Defaults to 30 days ago."
+//	@Param			end_date	query		string	false	"End date (YYYY-MM-DD), inclusive. Defaults to today."
+//	@Success		200			{object}	types.UsageReport
+//	@Failure		400			{object}	map[string]string	"Invalid date range"
+//	@Failure		500			{object}	map[string]string	"Failed to build report"
+//	@Security		BearerAuth
+//	@Router			/admin/reports/usage [get]
+func (h *ReportHandler) GetUsageReport(c echo.Context) error {
+	ctx := c.Request().Context()
+
+	// Parse the requested window, defaulting to the last 30 days.
+	now := time.Now().UTC()
+	end := time.Date(now.Year(), now.Month(), now.Day(), 23, 59, 59, 0, time.UTC)
+	start := end.AddDate(0, 0, -30)
+
+	if v := c.QueryParam("start_date"); v != "" {
+		t, err := time.Parse(dateFormat, v)
+		if err != nil {
+			return ErrorBadRequest(c, "invalid start_date, expected YYYY-MM-DD")
+		}
+		start = time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, time.UTC)
+	}
+	if v := c.QueryParam("end_date"); v != "" {
+		t, err := time.Parse(dateFormat, v)
+		if err != nil {
+			return ErrorBadRequest(c, "invalid end_date, expected YYYY-MM-DD")
+		}
+		end = time.Date(t.Year(), t.Month(), t.Day(), 23, 59, 59, 0, time.UTC)
+	}
+	if start.After(end) {
+		return ErrorBadRequest(c, "start_date must be on or before end_date")
+	}
+
+	clusters, err := h.store.Reports.GetClustersActiveInRange(ctx, start, end)
+	if err != nil {
+		return LogAndReturnGenericError(c, err)
+	}
+
+	// Resolve owner emails in one batch to avoid N+1 lookups.
+	ownerIDs := make([]string, 0, len(clusters))
+	seen := map[string]bool{}
+	for _, cl := range clusters {
+		if cl.OwnerID != "" && !seen[cl.OwnerID] {
+			seen[cl.OwnerID] = true
+			ownerIDs = append(ownerIDs, cl.OwnerID)
+		}
+	}
+	usersByID := map[string]*types.User{}
+	if len(ownerIDs) > 0 {
+		if usersByID, err = h.store.Users.GetByIDs(ctx, ownerIDs); err != nil {
+			// Non-fatal: fall back to owner IDs / emails on the cluster record.
+			LogWarning(c, "failed to resolve owner emails for usage report", "error", err.Error())
+			usersByID = map[string]*types.User{}
+		}
+	}
+
+	// Aggregate cost / profiles / users over the window.
+	profileAgg := map[string]*types.ProfileUsage{}
+	userAgg := map[string]*types.UserUsage{}
+	var totalCost, totalHours float64
+	var lifetimeSum float64
+	var lifetimeCount int
+
+	for _, cl := range clusters {
+		// Use GetAny so disabled/removed profiles still get costed.
+		prof, perr := h.registry.GetAny(cl.Profile)
+		var effective float64
+		var clusterCost, clusterHours float64
+		if perr == nil && prof != nil {
+			effective = cost.EffectiveHourlyCost(cl, prof)
+			clusterCost, clusterHours = cost.PeriodCost(cl, effective, start, end)
+		}
+
+		totalCost += clusterCost
+		totalHours += clusterHours
+
+		// Profile aggregation
+		pu := profileAgg[cl.Profile]
+		if pu == nil {
+			pu = &types.ProfileUsage{Profile: cl.Profile}
+			profileAgg[cl.Profile] = pu
+		}
+		pu.ClusterCount++
+		pu.RuntimeHours += clusterHours
+		pu.EstimatedCost += clusterCost
+
+		// User aggregation
+		ownerKey := cl.Owner
+		if ownerKey == "" {
+			ownerKey = cl.OwnerID
+		}
+		if u := usersByID[cl.OwnerID]; u != nil && u.Email != "" {
+			ownerKey = u.Email
+		}
+		uu := userAgg[ownerKey]
+		if uu == nil {
+			uu = &types.UserUsage{Owner: ownerKey}
+			userAgg[ownerKey] = uu
+		}
+		uu.ClusterCount++
+		uu.RuntimeHours += clusterHours
+		uu.EstimatedCost += clusterCost
+
+		// Average lifetime (over clusters active in-window)
+		lifeEnd := end
+		if cl.Status == types.ClusterStatusDestroyed && cl.DestroyedAt != nil {
+			lifeEnd = *cl.DestroyedAt
+		}
+		if lifeEnd.After(cl.CreatedAt) {
+			lifetimeSum += lifeEnd.Sub(cl.CreatedAt).Hours()
+			lifetimeCount++
+		}
+	}
+
+	// Job-derived lifecycle stats.
+	jobStats, err := h.store.Reports.GetJobStatsInRange(ctx, start, end)
+	if err != nil {
+		return LogAndReturnGenericError(c, err)
+	}
+	lifecycle := buildLifecycleStats(jobStats, clusters)
+	if lifetimeCount > 0 {
+		lifecycle.AvgLifetimeHours = lifetimeSum / float64(lifetimeCount)
+	}
+
+	// Sort profiles by cluster count desc, users by estimated cost desc.
+	profiles := make([]types.ProfileUsage, 0, len(profileAgg))
+	for _, pu := range profileAgg {
+		profiles = append(profiles, *pu)
+	}
+	sort.Slice(profiles, func(i, j int) bool {
+		if profiles[i].ClusterCount != profiles[j].ClusterCount {
+			return profiles[i].ClusterCount > profiles[j].ClusterCount
+		}
+		return profiles[i].EstimatedCost > profiles[j].EstimatedCost
+	})
+
+	users := make([]types.UserUsage, 0, len(userAgg))
+	for _, uu := range userAgg {
+		users = append(users, *uu)
+	}
+	sort.Slice(users, func(i, j int) bool {
+		if users[i].EstimatedCost != users[j].EstimatedCost {
+			return users[i].EstimatedCost > users[j].EstimatedCost
+		}
+		return users[i].ClusterCount > users[j].ClusterCount
+	})
+
+	// Prior-period comparison: an equally-sized window immediately preceding the
+	// current one. Queried separately so the current-window aggregations above
+	// (counts, breakdowns) only ever reflect clusters active in-window.
+	duration := end.Sub(start)
+	priorStart := start.Add(-duration)
+	priorEnd := start
+	var priorComparison *types.PeriodComparison
+	if priorClusters, perr := h.store.Reports.GetClustersActiveInRange(ctx, priorStart, priorEnd); perr != nil {
+		// Non-fatal: the report is still useful without the comparison.
+		LogWarning(c, "failed to compute prior-period cost for usage report", "error", perr.Error())
+	} else {
+		priorTotal := h.sumWindowCost(priorClusters, priorStart, priorEnd)
+		percentChange := 0.0
+		if priorTotal > 0 {
+			percentChange = ((totalCost - priorTotal) / priorTotal) * 100
+		}
+		priorComparison = &types.PeriodComparison{
+			CurrentPeriod:  totalCost,
+			PreviousPeriod: priorTotal,
+			PercentChange:  percentChange,
+			StartDate:      priorStart.Format(dateFormat),
+			EndDate:        priorEnd.Format(dateFormat),
+		}
+	}
+
+	report := &types.UsageReport{
+		StartDate:   start.Format(dateFormat),
+		EndDate:     end.Format(dateFormat),
+		GeneratedAt: now,
+		Cost: types.UsageCostSummary{
+			TotalCost:             totalCost,
+			TotalRuntimeHours:     totalHours,
+			ClustersActive:        len(clusters),
+			PriorPeriodComparison: priorComparison,
+		},
+		Profiles:  profiles,
+		Users:     users,
+		Lifecycle: lifecycle,
+	}
+
+	return SuccessOK(c, report)
+}
+
+// sumWindowCost returns the total estimated cost for the given clusters over the
+// window [start, end], using the same cost model as the main aggregation.
+func (h *ReportHandler) sumWindowCost(clusters []*types.Cluster, start, end time.Time) float64 {
+	var total float64
+	for _, cl := range clusters {
+		prof, err := h.registry.GetAny(cl.Profile)
+		if err != nil || prof == nil {
+			continue
+		}
+		eff := cost.EffectiveHourlyCost(cl, prof)
+		c, _ := cost.PeriodCost(cl, eff, start, end)
+		total += c
+	}
+	return total
+}
+
+// buildLifecycleStats folds job counts and cluster breakdowns into the report's
+// lifecycle section.
+func buildLifecycleStats(jobStats *types.JobStats, clusters []*types.Cluster) types.LifecycleStats {
+	ls := types.LifecycleStats{
+		ByPlatform:    map[string]int{},
+		ByClusterType: map[string]int{},
+		ByStatus:      map[string]int{},
+	}
+
+	succeeded := string(types.JobStatusSucceeded)
+	failed := string(types.JobStatusFailed)
+
+	count := func(jobType, status string) int {
+		if m := jobStats.Counts[jobType]; m != nil {
+			return m[status]
+		}
+		return 0
+	}
+
+	ls.Created = count(string(types.JobTypeCreate), succeeded)
+	ls.Destroyed = count(string(types.JobTypeDestroy), succeeded) +
+		count(string(types.JobTypeJanitorDestroy), succeeded)
+	ls.Hibernated = count(string(types.JobTypeHibernate), succeeded)
+
+	ls.CreateSuccess = count(string(types.JobTypeCreate), succeeded)
+	ls.CreateFailure = count(string(types.JobTypeCreate), failed)
+	if completed := ls.CreateSuccess + ls.CreateFailure; completed > 0 {
+		ls.CreateSuccessRate = float64(ls.CreateSuccess) / float64(completed)
+	}
+
+	for _, cl := range clusters {
+		ls.ByPlatform[string(cl.Platform)]++
+		ls.ByClusterType[string(cl.ClusterType)]++
+		ls.ByStatus[string(cl.Status)]++
+	}
+
+	return ls
+}

--- a/internal/api/handler_reports_api_test.go
+++ b/internal/api/handler_reports_api_test.go
@@ -1,0 +1,86 @@
+package api_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tsanders-rh/ocpctl/internal/api"
+	"github.com/tsanders-rh/ocpctl/internal/store"
+	"github.com/tsanders-rh/ocpctl/pkg/types"
+)
+
+// TestReportHandler_GetUsageReport_BadRange verifies the date-range validation,
+// which runs before any store access (so no database is required).
+func TestReportHandler_GetUsageReport_BadRange(t *testing.T) {
+	handler := api.NewReportHandler(nil, nil)
+
+	cases := []struct {
+		name  string
+		query string
+	}{
+		{"malformed start_date", "start_date=not-a-date&end_date=2026-01-31"},
+		{"malformed end_date", "start_date=2026-01-01&end_date=nope"},
+		{"start after end", "start_date=2026-02-01&end_date=2026-01-01"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			e := echo.New()
+			req := httptest.NewRequest(http.MethodGet, "/admin/reports/usage?"+tc.query, nil)
+			rec := httptest.NewRecorder()
+			c := e.NewContext(req, rec)
+
+			err := handler.GetUsageReport(c)
+			require.NoError(t, err) // handler writes JSON and returns nil
+			assert.Equal(t, http.StatusBadRequest, rec.Code)
+		})
+	}
+}
+
+// TestReportHandler_GetUsageReport_HappyPath is an integration test exercising
+// the full aggregation path against a real database. It is skipped until a test
+// database harness is configured (see setupTestDB).
+func TestReportHandler_GetUsageReport_HappyPath(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test")
+	}
+
+	pool := setupTestDB(t)
+	defer pool.Close()
+	s := store.New(pool)
+	handler := api.NewReportHandler(s, nil)
+
+	// Seed a couple of clusters active within the window.
+	user := createTestUser(t, s, "reporter@example.com", types.RoleUser)
+	createTestCluster(t, s, user.ID, "engineering")
+	createTestCluster(t, s, user.ID, "engineering")
+
+	end := time.Now().UTC()
+	start := end.AddDate(0, 0, -30)
+
+	e := echo.New()
+	url := "/admin/reports/usage?start_date=" + start.Format("2006-01-02") +
+		"&end_date=" + end.Format("2006-01-02")
+	req := httptest.NewRequest(http.MethodGet, url, nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	setAuthContext(c, createTestUser(t, s, "admin@example.com", types.RoleAdmin))
+
+	require.NoError(t, handler.GetUsageReport(c))
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var report types.UsageReport
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &report))
+
+	assert.Equal(t, start.Format("2006-01-02"), report.StartDate)
+	assert.Equal(t, end.Format("2006-01-02"), report.EndDate)
+	assert.GreaterOrEqual(t, report.Cost.ClustersActive, 2)
+	assert.NotNil(t, report.Lifecycle.ByPlatform)
+	assert.NotEmpty(t, report.Profiles)
+}

--- a/internal/api/handler_reports_test.go
+++ b/internal/api/handler_reports_test.go
@@ -1,0 +1,57 @@
+package api
+
+import (
+	"testing"
+
+	"github.com/tsanders-rh/ocpctl/pkg/types"
+)
+
+func TestBuildLifecycleStats(t *testing.T) {
+	stats := &types.JobStats{Counts: map[string]map[string]int{
+		string(types.JobTypeCreate):         {"SUCCEEDED": 8, "FAILED": 2},
+		string(types.JobTypeDestroy):        {"SUCCEEDED": 3},
+		string(types.JobTypeJanitorDestroy): {"SUCCEEDED": 2},
+		string(types.JobTypeHibernate):      {"SUCCEEDED": 4},
+	}}
+
+	clusters := []*types.Cluster{
+		{Platform: types.PlatformAWS, ClusterType: types.ClusterTypeOpenShift, Status: types.ClusterStatusReady},
+		{Platform: types.PlatformAWS, ClusterType: types.ClusterTypeEKS, Status: types.ClusterStatusDestroyed},
+		{Platform: types.PlatformGCP, ClusterType: types.ClusterTypeGKE, Status: types.ClusterStatusReady},
+	}
+
+	ls := buildLifecycleStats(stats, clusters)
+
+	if ls.Created != 8 {
+		t.Errorf("Created = %d, want 8", ls.Created)
+	}
+	if ls.Destroyed != 5 { // 3 destroy + 2 janitor destroy
+		t.Errorf("Destroyed = %d, want 5", ls.Destroyed)
+	}
+	if ls.Hibernated != 4 {
+		t.Errorf("Hibernated = %d, want 4", ls.Hibernated)
+	}
+	if ls.CreateSuccess != 8 || ls.CreateFailure != 2 {
+		t.Errorf("CreateSuccess/Failure = %d/%d, want 8/2", ls.CreateSuccess, ls.CreateFailure)
+	}
+	if ls.CreateSuccessRate != 0.8 {
+		t.Errorf("CreateSuccessRate = %v, want 0.8", ls.CreateSuccessRate)
+	}
+	if ls.ByPlatform["aws"] != 2 || ls.ByPlatform["gcp"] != 1 {
+		t.Errorf("ByPlatform = %v", ls.ByPlatform)
+	}
+	if ls.ByClusterType["openshift"] != 1 || ls.ByClusterType["eks"] != 1 || ls.ByClusterType["gke"] != 1 {
+		t.Errorf("ByClusterType = %v", ls.ByClusterType)
+	}
+	if ls.ByStatus["READY"] != 2 || ls.ByStatus["DESTROYED"] != 1 {
+		t.Errorf("ByStatus = %v", ls.ByStatus)
+	}
+}
+
+func TestBuildLifecycleStats_NoCreateJobs(t *testing.T) {
+	stats := &types.JobStats{Counts: map[string]map[string]int{}}
+	ls := buildLifecycleStats(stats, nil)
+	if ls.CreateSuccessRate != 0 {
+		t.Errorf("CreateSuccessRate = %v, want 0 (no completed create jobs)", ls.CreateSuccessRate)
+	}
+}

--- a/internal/api/handler_teams.go
+++ b/internal/api/handler_teams.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/labstack/echo/v4"
 	"github.com/tsanders-rh/ocpctl/internal/auth"
+	"github.com/tsanders-rh/ocpctl/internal/cost"
 	"github.com/tsanders-rh/ocpctl/internal/profile"
 	"github.com/tsanders-rh/ocpctl/internal/store"
 	"github.com/tsanders-rh/ocpctl/pkg/types"
@@ -719,75 +720,16 @@ func (h *TeamHandler) GetTeamCosts(c echo.Context) error {
 }
 
 // calculateEffectiveCost calculates the effective hourly cost based on cluster state
-// Hibernated clusters cost significantly less than running clusters
+// Hibernated clusters cost significantly less than running clusters.
+// Delegates to the shared cost.EffectiveHourlyCost implementation.
 func (h *TeamHandler) calculateEffectiveCost(cluster *types.Cluster, prof *profile.Profile) float64 {
-	baseCost := prof.CostControls.EstimatedHourlyCost
-
-	// If cluster is hibernated, calculate reduced cost based on cluster type
-	if cluster.Status == types.ClusterStatusHibernated {
-		switch cluster.ClusterType {
-		case types.ClusterTypeOpenShift:
-			// OpenShift: All instances stopped, only persistent storage remains (~10%)
-			return baseCost * 0.10
-		case types.ClusterTypeROSA:
-			// ROSA: Machine pools scaled to 0, but control plane runs at fixed $0.03/hr
-			return 0.03
-		case types.ClusterTypeEKS:
-			// EKS: Node groups scaled to 0, control plane at $0.10/hr
-			return 0.10
-		case types.ClusterTypeIKS:
-			// IKS: Workers scaled to 0, minimal cost (~5%)
-			return baseCost * 0.05
-		case types.ClusterTypeGKE:
-			// GKE: Node pools scaled to 0, no control plane cost, only persistent disks (~3%)
-			return baseCost * 0.03
-		default:
-			// Unknown cluster type, use conservative estimate
-			return baseCost * 0.10
-		}
-	}
-
-	// For all other states (READY, CREATING, etc.), use full cost
-	return baseCost
+	return cost.EffectiveHourlyCost(cluster, prof)
 }
 
-// calculatePeriodCost calculates cost and runtime hours for a specific period
+// calculatePeriodCost calculates cost and runtime hours for a specific period.
+// Delegates to the shared cost.PeriodCost implementation.
 func (h *TeamHandler) calculatePeriodCost(cluster *types.Cluster, effectiveCost float64, periodStart, periodEnd time.Time) (float64, float64) {
-	// Determine cluster's active period within the date range
-	clusterStart := cluster.CreatedAt
-	clusterEnd := periodEnd // Assume still running
-
-	// If cluster is destroyed, use destroyed_at as the end time
-	if cluster.Status == types.ClusterStatusDestroyed && cluster.DestroyedAt != nil {
-		clusterEnd = *cluster.DestroyedAt
-	}
-
-	// Calculate intersection of cluster lifetime and period
-	activeStart := clusterStart
-	if periodStart.After(clusterStart) {
-		activeStart = periodStart
-	}
-
-	activeEnd := clusterEnd
-	if periodEnd.Before(clusterEnd) {
-		activeEnd = periodEnd
-	}
-
-	// If cluster wasn't active during this period, return 0
-	if activeStart.After(activeEnd) || activeStart.After(periodEnd) || activeEnd.Before(periodStart) {
-		return 0.0, 0.0
-	}
-
-	// Calculate runtime hours
-	runtimeHours := activeEnd.Sub(activeStart).Hours()
-	if runtimeHours < 0 {
-		runtimeHours = 0
-	}
-
-	// Calculate total cost
-	totalCost := runtimeHours * effectiveCost
-
-	return totalCost, runtimeHours
+	return cost.PeriodCost(cluster, effectiveCost, periodStart, periodEnd)
 }
 
 // calculateDailyCosts calculates cost for each day in the specified number of days

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -299,6 +299,10 @@ func (s *Server) setupRoutes() {
 	adminGroup.POST("/windows-snapshots", windowsSnapshotHandler.CreateWindowsSnapshot)
 	adminGroup.DELETE("/windows-snapshots/:id", windowsSnapshotHandler.DeleteWindowsSnapshot)
 
+	// Usage report (admin only)
+	reportHandler := NewReportHandler(s.store, s.registry)
+	adminGroup.GET("/reports/usage", reportHandler.GetUsageReport)
+
 	// Team management routes
 	teamHandler := NewTeamHandler(s.store, s.registry)
 

--- a/internal/cost/estimate.go
+++ b/internal/cost/estimate.go
@@ -1,0 +1,87 @@
+package cost
+
+import (
+	"time"
+
+	"github.com/tsanders-rh/ocpctl/internal/profile"
+	"github.com/tsanders-rh/ocpctl/pkg/types"
+)
+
+// EffectiveHourlyCost returns the effective hourly cost for a cluster based on
+// its current state. Hibernated clusters cost significantly less than running
+// clusters, and the reduction depends on the cluster type.
+//
+// This is the shared implementation used by both the per-team costs endpoint and
+// the platform-wide usage report so cost figures stay consistent across surfaces.
+func EffectiveHourlyCost(cluster *types.Cluster, prof *profile.Profile) float64 {
+	baseCost := prof.CostControls.EstimatedHourlyCost
+
+	// If cluster is hibernated, calculate reduced cost based on cluster type
+	if cluster.Status == types.ClusterStatusHibernated {
+		switch cluster.ClusterType {
+		case types.ClusterTypeOpenShift:
+			// OpenShift: All instances stopped, only persistent storage remains (~10%)
+			return baseCost * 0.10
+		case types.ClusterTypeROSA:
+			// ROSA: Machine pools scaled to 0, but control plane runs at fixed $0.03/hr
+			return 0.03
+		case types.ClusterTypeEKS:
+			// EKS: Node groups scaled to 0, control plane at $0.10/hr
+			return 0.10
+		case types.ClusterTypeIKS:
+			// IKS: Workers scaled to 0, minimal cost (~5%)
+			return baseCost * 0.05
+		case types.ClusterTypeGKE:
+			// GKE: Node pools scaled to 0, no control plane cost, only persistent disks (~3%)
+			return baseCost * 0.03
+		default:
+			// Unknown cluster type, use conservative estimate
+			return baseCost * 0.10
+		}
+	}
+
+	// For all other states (READY, CREATING, etc.), use full cost
+	return baseCost
+}
+
+// PeriodCost returns the estimated cost and runtime hours for a cluster within
+// the window [periodStart, periodEnd]. It intersects the cluster's lifetime
+// (CreatedAt .. DestroyedAt/now) with the window; a cluster that was not active
+// during the window contributes zero cost and zero hours.
+func PeriodCost(cluster *types.Cluster, effectiveCost float64, periodStart, periodEnd time.Time) (float64, float64) {
+	// Determine cluster's active period within the date range
+	clusterStart := cluster.CreatedAt
+	clusterEnd := periodEnd // Assume still running
+
+	// If cluster is destroyed, use destroyed_at as the end time
+	if cluster.Status == types.ClusterStatusDestroyed && cluster.DestroyedAt != nil {
+		clusterEnd = *cluster.DestroyedAt
+	}
+
+	// Calculate intersection of cluster lifetime and period
+	activeStart := clusterStart
+	if periodStart.After(clusterStart) {
+		activeStart = periodStart
+	}
+
+	activeEnd := clusterEnd
+	if periodEnd.Before(clusterEnd) {
+		activeEnd = periodEnd
+	}
+
+	// If cluster wasn't active during this period, return 0
+	if activeStart.After(activeEnd) || activeStart.After(periodEnd) || activeEnd.Before(periodStart) {
+		return 0.0, 0.0
+	}
+
+	// Calculate runtime hours
+	runtimeHours := activeEnd.Sub(activeStart).Hours()
+	if runtimeHours < 0 {
+		runtimeHours = 0
+	}
+
+	// Calculate total cost
+	totalCost := runtimeHours * effectiveCost
+
+	return totalCost, runtimeHours
+}

--- a/internal/cost/estimate_test.go
+++ b/internal/cost/estimate_test.go
@@ -1,0 +1,95 @@
+package cost
+
+import (
+	"testing"
+	"time"
+
+	"github.com/tsanders-rh/ocpctl/internal/profile"
+	"github.com/tsanders-rh/ocpctl/pkg/types"
+)
+
+func prof(hourly float64) *profile.Profile {
+	return &profile.Profile{
+		CostControls: profile.CostControlsConfig{EstimatedHourlyCost: hourly},
+	}
+}
+
+func TestEffectiveHourlyCost(t *testing.T) {
+	tests := []struct {
+		name   string
+		status types.ClusterStatus
+		ctype  types.ClusterType
+		base   float64
+		want   float64
+	}{
+		{"running full cost", types.ClusterStatusReady, types.ClusterTypeOpenShift, 1.0, 1.0},
+		{"hibernated openshift 10pct", types.ClusterStatusHibernated, types.ClusterTypeOpenShift, 1.0, 0.10},
+		{"hibernated rosa fixed", types.ClusterStatusHibernated, types.ClusterTypeROSA, 1.0, 0.03},
+		{"hibernated eks fixed", types.ClusterStatusHibernated, types.ClusterTypeEKS, 1.0, 0.10},
+		{"hibernated gke 3pct", types.ClusterStatusHibernated, types.ClusterTypeGKE, 1.0, 0.03},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cl := &types.Cluster{Status: tc.status, ClusterType: tc.ctype}
+			got := EffectiveHourlyCost(cl, prof(tc.base))
+			if got != tc.want {
+				t.Fatalf("EffectiveHourlyCost = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestPeriodCost(t *testing.T) {
+	winStart := time.Date(2026, 1, 10, 0, 0, 0, 0, time.UTC)
+	winEnd := time.Date(2026, 1, 20, 0, 0, 0, 0, time.UTC)
+
+	t.Run("lifetime fully inside window", func(t *testing.T) {
+		created := time.Date(2026, 1, 12, 0, 0, 0, 0, time.UTC)
+		destroyed := time.Date(2026, 1, 14, 0, 0, 0, 0, time.UTC)
+		cl := &types.Cluster{
+			Status:      types.ClusterStatusDestroyed,
+			CreatedAt:   created,
+			DestroyedAt: &destroyed,
+		}
+		cost, hours := PeriodCost(cl, 2.0, winStart, winEnd)
+		if hours != 48 {
+			t.Fatalf("hours = %v, want 48", hours)
+		}
+		if cost != 96 {
+			t.Fatalf("cost = %v, want 96", cost)
+		}
+	})
+
+	t.Run("created before window, still running clamps to window", func(t *testing.T) {
+		created := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+		cl := &types.Cluster{Status: types.ClusterStatusReady, CreatedAt: created}
+		_, hours := PeriodCost(cl, 1.0, winStart, winEnd)
+		wantHours := winEnd.Sub(winStart).Hours() // full 10 days = 240h
+		if hours != wantHours {
+			t.Fatalf("hours = %v, want %v", hours, wantHours)
+		}
+	})
+
+	t.Run("destroyed before window returns zero", func(t *testing.T) {
+		created := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+		destroyed := time.Date(2026, 1, 5, 0, 0, 0, 0, time.UTC)
+		cl := &types.Cluster{
+			Status:      types.ClusterStatusDestroyed,
+			CreatedAt:   created,
+			DestroyedAt: &destroyed,
+		}
+		cost, hours := PeriodCost(cl, 1.0, winStart, winEnd)
+		if cost != 0 || hours != 0 {
+			t.Fatalf("cost/hours = %v/%v, want 0/0", cost, hours)
+		}
+	})
+
+	t.Run("created after window returns zero", func(t *testing.T) {
+		created := time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC)
+		cl := &types.Cluster{Status: types.ClusterStatusReady, CreatedAt: created}
+		cost, hours := PeriodCost(cl, 1.0, winStart, winEnd)
+		if cost != 0 || hours != 0 {
+			t.Fatalf("cost/hours = %v/%v, want 0/0", cost, hours)
+		}
+	})
+}

--- a/internal/store/report.go
+++ b/internal/store/report.go
@@ -1,0 +1,105 @@
+package store
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/tsanders-rh/ocpctl/pkg/types"
+)
+
+// ReportStore provides aggregate read queries backing the usage report.
+type ReportStore struct {
+	pool *pgxpool.Pool
+}
+
+// GetClustersActiveInRange returns every cluster whose lifetime overlaps the
+// window [start, end]. A cluster is considered active if it was created on or
+// before the end of the window and was either not yet destroyed or destroyed on
+// or after the start of the window.
+//
+// Only the columns needed by the usage report are selected; the rest of the
+// Cluster struct is left zero-valued.
+func (s *ReportStore) GetClustersActiveInRange(ctx context.Context, start, end time.Time) ([]*types.Cluster, error) {
+	query := `
+		SELECT id, name, platform, cluster_type, profile, region,
+			owner, owner_id, team, status, created_at, destroyed_at
+		FROM clusters
+		WHERE created_at <= $2
+		  AND (destroyed_at IS NULL OR destroyed_at >= $1)
+		ORDER BY created_at DESC
+	`
+
+	rows, err := s.pool.Query(ctx, query, start, end)
+	if err != nil {
+		return nil, fmt.Errorf("query clusters active in range: %w", err)
+	}
+	defer rows.Close()
+
+	clusters := []*types.Cluster{}
+	for rows.Next() {
+		var c types.Cluster
+		if err := rows.Scan(
+			&c.ID,
+			&c.Name,
+			&c.Platform,
+			&c.ClusterType,
+			&c.Profile,
+			&c.Region,
+			&c.Owner,
+			&c.OwnerID,
+			&c.Team,
+			&c.Status,
+			&c.CreatedAt,
+			&c.DestroyedAt,
+		); err != nil {
+			return nil, fmt.Errorf("scan cluster: %w", err)
+		}
+		clusters = append(clusters, &c)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate clusters: %w", err)
+	}
+
+	return clusters, nil
+}
+
+// GetJobStatsInRange returns job counts grouped by job type and status for jobs
+// created within the window [start, end]. The handler folds these into the
+// report's lifecycle section (created/destroyed/hibernated counts, create
+// success rate).
+func (s *ReportStore) GetJobStatsInRange(ctx context.Context, start, end time.Time) (*types.JobStats, error) {
+	query := `
+		SELECT job_type, status, COUNT(*)
+		FROM jobs
+		WHERE created_at >= $1 AND created_at <= $2
+		GROUP BY job_type, status
+	`
+
+	rows, err := s.pool.Query(ctx, query, start, end)
+	if err != nil {
+		return nil, fmt.Errorf("query job stats in range: %w", err)
+	}
+	defer rows.Close()
+
+	stats := &types.JobStats{Counts: map[string]map[string]int{}}
+	for rows.Next() {
+		var jobType, status string
+		var count int
+		if err := rows.Scan(&jobType, &status, &count); err != nil {
+			return nil, fmt.Errorf("scan job stats: %w", err)
+		}
+		if stats.Counts[jobType] == nil {
+			stats.Counts[jobType] = map[string]int{}
+		}
+		stats.Counts[jobType][status] = count
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate job stats: %w", err)
+	}
+
+	return stats, nil
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -61,6 +61,7 @@ type Store struct {
 	TeamAdmins               *TeamAdminStore
 	TeamMemberships          *TeamMembershipStore
 	Pools                    *PoolStore
+	Reports                  *ReportStore
 }
 
 // New creates a new Store with all sub-stores initialized using the provided database connection pool.
@@ -101,6 +102,7 @@ func New(pool *pgxpool.Pool) *Store {
 	s.TeamAdmins = &TeamAdminStore{db: pool}
 	s.TeamMemberships = &TeamMembershipStore{db: pool}
 	s.Pools = &PoolStore{pool: pool}
+	s.Reports = &ReportStore{pool: pool}
 
 	return s
 }

--- a/pkg/types/report.go
+++ b/pkg/types/report.go
@@ -1,0 +1,65 @@
+package types
+
+import "time"
+
+// UsageReport is the platform-wide, date-ranged usage/cost report returned by
+// GET /api/v1/admin/reports/usage. All figures are estimates derived from
+// profile hourly rates and cluster runtime within the requested window.
+type UsageReport struct {
+	StartDate   string    `json:"start_date"` // YYYY-MM-DD (inclusive)
+	EndDate     string    `json:"end_date"`   // YYYY-MM-DD (inclusive)
+	GeneratedAt time.Time `json:"generated_at"`
+
+	Cost      UsageCostSummary `json:"cost"`
+	Profiles  []ProfileUsage   `json:"profiles"` // sorted by cluster count desc
+	Users     []UserUsage      `json:"users"`    // sorted by est. cost desc
+	Lifecycle LifecycleStats   `json:"lifecycle"`
+}
+
+// UsageCostSummary captures the headline cost numbers for the report window.
+type UsageCostSummary struct {
+	TotalCost             float64           `json:"total_cost"`                        // estimated $ across all clusters in-window
+	TotalRuntimeHours     float64           `json:"total_runtime_hours"`               // summed cluster runtime hours in-window
+	ClustersActive        int               `json:"clusters_active"`                   // clusters active at any point in-window
+	PriorPeriodComparison *PeriodComparison `json:"prior_period_comparison,omitempty"` // vs. the equally-sized preceding window
+}
+
+// ProfileUsage aggregates usage for a single profile within the window.
+type ProfileUsage struct {
+	Profile       string  `json:"profile"`
+	ClusterCount  int     `json:"cluster_count"`
+	RuntimeHours  float64 `json:"runtime_hours"`
+	EstimatedCost float64 `json:"estimated_cost"`
+}
+
+// UserUsage aggregates usage for a single owner within the window.
+type UserUsage struct {
+	Owner         string  `json:"owner"` // email when resolvable, else owner_id
+	ClusterCount  int     `json:"cluster_count"`
+	RuntimeHours  float64 `json:"runtime_hours"`
+	EstimatedCost float64 `json:"estimated_cost"`
+}
+
+// LifecycleStats summarizes cluster lifecycle activity in the window. Counts are
+// derived from jobs created in-window; breakdowns are over clusters active
+// in-window.
+type LifecycleStats struct {
+	Created           int     `json:"created"`             // CREATE jobs that succeeded
+	Destroyed         int     `json:"destroyed"`           // DESTROY/JANITOR_DESTROY jobs that succeeded
+	Hibernated        int     `json:"hibernated"`          // HIBERNATE jobs that succeeded
+	CreateSuccess     int     `json:"create_success"`      // successful CREATE jobs
+	CreateFailure     int     `json:"create_failure"`      // failed CREATE jobs
+	CreateSuccessRate float64 `json:"create_success_rate"` // 0..1, over completed CREATE jobs
+	AvgLifetimeHours  float64 `json:"avg_lifetime_hours"`  // avg lifetime of clusters active in-window
+
+	ByPlatform    map[string]int `json:"by_platform"`
+	ByClusterType map[string]int `json:"by_cluster_type"`
+	ByStatus      map[string]int `json:"by_status"`
+}
+
+// JobStats is the raw aggregate of jobs within a window, keyed by job type and
+// status, produced by the store and folded into LifecycleStats by the handler.
+type JobStats struct {
+	// Counts[jobType][status] = count
+	Counts map[string]map[string]int `json:"counts"`
+}

--- a/web/app/(dashboard)/admin/usage-report/page.tsx
+++ b/web/app/(dashboard)/admin/usage-report/page.tsx
@@ -1,0 +1,302 @@
+"use client";
+
+import { useState } from "react";
+import { format, subDays, startOfMonth, startOfQuarter } from "date-fns";
+import { useUsageReport } from "@/lib/hooks/useUsageReport";
+import { exportUsageReportPdf } from "@/lib/reports/exportPdf";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { formatCurrency } from "@/lib/utils/formatters";
+import { BarChart } from "@tremor/react";
+import { Download, FileText } from "lucide-react";
+
+const fmt = (d: Date) => format(d, "yyyy-MM-dd");
+
+type Preset = { label: string; range: () => [string, string] };
+
+const PRESETS: Preset[] = [
+  { label: "Last 7 days", range: () => [fmt(subDays(new Date(), 7)), fmt(new Date())] },
+  { label: "Last 30 days", range: () => [fmt(subDays(new Date(), 30)), fmt(new Date())] },
+  { label: "Last 90 days", range: () => [fmt(subDays(new Date(), 90)), fmt(new Date())] },
+  { label: "This month", range: () => [fmt(startOfMonth(new Date())), fmt(new Date())] },
+  { label: "This quarter", range: () => [fmt(startOfQuarter(new Date())), fmt(new Date())] },
+];
+
+export default function UsageReportPage() {
+  const [startDate, setStartDate] = useState(fmt(subDays(new Date(), 30)));
+  const [endDate, setEndDate] = useState(fmt(new Date()));
+
+  const { data: report, isLoading, error } = useUsageReport(startDate, endDate);
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-3xl font-bold flex items-center gap-2">
+            <FileText className="h-7 w-7" /> Usage Report
+          </h1>
+          <p className="text-muted-foreground">
+            Estimated cost, most used profiles, most active users, and cluster lifecycle stats.
+          </p>
+        </div>
+        <Button
+          onClick={() => report && exportUsageReportPdf(report)}
+          disabled={!report}
+          className="gap-2"
+        >
+          <Download className="h-4 w-4" /> Download PDF
+        </Button>
+      </div>
+
+      {/* Range picker */}
+      <Card>
+        <CardContent className="pt-6 space-y-4">
+          <div className="flex flex-wrap gap-2">
+            {PRESETS.map((p) => (
+              <Button
+                key={p.label}
+                variant="outline"
+                size="sm"
+                onClick={() => {
+                  const [s, e] = p.range();
+                  setStartDate(s);
+                  setEndDate(e);
+                }}
+              >
+                {p.label}
+              </Button>
+            ))}
+          </div>
+          <div className="flex flex-wrap items-end gap-4">
+            <div className="space-y-1">
+              <Label htmlFor="start">Start date</Label>
+              <Input
+                id="start"
+                type="date"
+                value={startDate}
+                max={endDate}
+                onChange={(e) => setStartDate(e.target.value)}
+                className="w-44"
+              />
+            </div>
+            <div className="space-y-1">
+              <Label htmlFor="end">End date</Label>
+              <Input
+                id="end"
+                type="date"
+                value={endDate}
+                min={startDate}
+                onChange={(e) => setEndDate(e.target.value)}
+                className="w-44"
+              />
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      {isLoading && <p className="text-muted-foreground">Loading report…</p>}
+      {error && (
+        <p className="text-destructive">Failed to load report: {(error as Error).message}</p>
+      )}
+
+      {report && (
+        <>
+          {/* Summary cards */}
+          <div className="grid gap-4 md:grid-cols-4">
+            <SummaryCard
+              title="Total estimated cost"
+              value={formatCurrency(report.cost.total_cost)}
+              subtitle={
+                report.cost.prior_period_comparison
+                  ? `${
+                      report.cost.prior_period_comparison.percent_change >= 0 ? "▲" : "▼"
+                    } ${Math.abs(
+                      report.cost.prior_period_comparison.percent_change
+                    ).toFixed(1)}% vs prior period`
+                  : `${report.cost.total_runtime_hours.toFixed(0)} runtime hrs`
+              }
+            />
+            <SummaryCard
+              title="Clusters active"
+              value={String(report.cost.clusters_active)}
+              subtitle={`${report.lifecycle.created} created · ${report.lifecycle.destroyed} destroyed`}
+            />
+            <SummaryCard
+              title="Avg lifetime"
+              value={`${report.lifecycle.avg_lifetime_hours.toFixed(1)} hrs`}
+              subtitle={`${report.lifecycle.hibernated} hibernated`}
+            />
+            <SummaryCard
+              title="Create success rate"
+              value={`${(report.lifecycle.create_success_rate * 100).toFixed(0)}%`}
+              subtitle={`${report.lifecycle.create_success}/${
+                report.lifecycle.create_success + report.lifecycle.create_failure
+              } jobs`}
+            />
+          </div>
+
+          {/* Most used profiles */}
+          <Card>
+            <CardHeader>
+              <CardTitle>Most Used Profiles</CardTitle>
+              <CardDescription>Ranked by cluster count over the selected range</CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-6">
+              {report.profiles.length > 0 && (
+                <BarChart
+                  data={report.profiles.slice(0, 10)}
+                  index="profile"
+                  categories={["cluster_count"]}
+                  colors={["blue"]}
+                  showLegend={false}
+                  yAxisWidth={40}
+                  className="h-64"
+                />
+              )}
+              <UsageTable
+                rows={report.profiles}
+                nameHeader="Profile"
+                nameKey="profile"
+                emptyText="No profiles in range"
+              />
+            </CardContent>
+          </Card>
+
+          {/* Most active users */}
+          <Card>
+            <CardHeader>
+              <CardTitle>Most Active Users</CardTitle>
+              <CardDescription>Ranked by estimated cost over the selected range</CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-6">
+              {report.users.length > 0 && (
+                <BarChart
+                  data={report.users.slice(0, 10)}
+                  index="owner"
+                  categories={["estimated_cost"]}
+                  colors={["emerald"]}
+                  showLegend={false}
+                  valueFormatter={(v) => formatCurrency(v)}
+                  yAxisWidth={64}
+                  className="h-64"
+                />
+              )}
+              <UsageTable
+                rows={report.users}
+                nameHeader="User"
+                nameKey="owner"
+                emptyText="No users in range"
+              />
+            </CardContent>
+          </Card>
+
+          {/* Lifecycle breakdowns */}
+          <div className="grid gap-4 md:grid-cols-3">
+            <BreakdownCard title="By Platform" data={report.lifecycle.by_platform} />
+            <BreakdownCard title="By Cluster Type" data={report.lifecycle.by_cluster_type} />
+            <BreakdownCard title="By Status" data={report.lifecycle.by_status} />
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+
+function SummaryCard({
+  title,
+  value,
+  subtitle,
+}: {
+  title: string;
+  value: string;
+  subtitle?: string;
+}) {
+  return (
+    <Card>
+      <CardContent className="pt-6">
+        <p className="text-sm text-muted-foreground">{title}</p>
+        <p className="text-2xl font-bold">{value}</p>
+        {subtitle && <p className="text-xs text-muted-foreground mt-1">{subtitle}</p>}
+      </CardContent>
+    </Card>
+  );
+}
+
+function UsageTable({
+  rows,
+  nameHeader,
+  nameKey,
+  emptyText,
+}: {
+  rows: Array<{
+    profile?: string;
+    owner?: string;
+    cluster_count: number;
+    runtime_hours: number;
+    estimated_cost: number;
+  }>;
+  nameHeader: string;
+  nameKey: "profile" | "owner";
+  emptyText: string;
+}) {
+  if (rows.length === 0) {
+    return <p className="text-sm text-muted-foreground">{emptyText}</p>;
+  }
+  return (
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableHead>{nameHeader}</TableHead>
+          <TableHead className="text-right">Clusters</TableHead>
+          <TableHead className="text-right">Runtime hrs</TableHead>
+          <TableHead className="text-right">Est. cost</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {rows.map((r) => (
+          <TableRow key={(r[nameKey] as string) || "unknown"}>
+            <TableCell className="font-medium">{r[nameKey]}</TableCell>
+            <TableCell className="text-right">{r.cluster_count}</TableCell>
+            <TableCell className="text-right">{r.runtime_hours.toFixed(1)}</TableCell>
+            <TableCell className="text-right">{formatCurrency(r.estimated_cost)}</TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  );
+}
+
+function BreakdownCard({ title, data }: { title: string; data: Record<string, number> }) {
+  const entries = Object.entries(data).sort((a, b) => b[1] - a[1]);
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base">{title}</CardTitle>
+      </CardHeader>
+      <CardContent>
+        {entries.length === 0 ? (
+          <p className="text-sm text-muted-foreground">No data</p>
+        ) : (
+          <div className="space-y-2">
+            {entries.map(([k, v]) => (
+              <div key={k} className="flex justify-between text-sm">
+                <span className="text-muted-foreground">{k}</span>
+                <span className="font-medium">{v}</span>
+              </div>
+            ))}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/web/components/layout/Sidebar.tsx
+++ b/web/components/layout/Sidebar.tsx
@@ -3,7 +3,7 @@
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { cn } from "@/lib/utils/cn";
-import { Layers, FileCode, Home, Shield, Users, BookOpen, BookText, Clock, PackageCheck, UsersRound, Activity, Database, HardDrive } from "lucide-react";
+import { Layers, FileCode, Home, Shield, Users, BookOpen, BookText, Clock, PackageCheck, UsersRound, Activity, Database, HardDrive, FileText } from "lucide-react";
 import { useAuthStore } from "@/lib/stores/authStore";
 import { UserRole } from "@/types/api";
 
@@ -33,6 +33,7 @@ const adminNavigation = [
   { name: "Windows Snapshots", href: "/admin/windows-snapshots", icon: HardDrive },
   { name: "Profile Updates", href: "/admin/profile-updates", icon: PackageCheck },
   { name: "Long-Running Clusters", href: "/admin/long-running-clusters", icon: Clock },
+  { name: "Usage Report", href: "/admin/usage-report", icon: FileText },
 ];
 
 export function Sidebar() {

--- a/web/lib/api/endpoints/reports.ts
+++ b/web/lib/api/endpoints/reports.ts
@@ -1,0 +1,60 @@
+import { apiClient } from "../client";
+
+// Mirrors pkg/types/report.go
+
+export interface UsageCostSummary {
+  total_cost: number;
+  total_runtime_hours: number;
+  clusters_active: number;
+  prior_period_comparison?: {
+    current_period: number;
+    previous_period: number;
+    percent_change: number;
+    start_date: string;
+    end_date: string;
+  };
+}
+
+export interface ProfileUsage {
+  profile: string;
+  cluster_count: number;
+  runtime_hours: number;
+  estimated_cost: number;
+}
+
+export interface UserUsage {
+  owner: string;
+  cluster_count: number;
+  runtime_hours: number;
+  estimated_cost: number;
+}
+
+export interface LifecycleStats {
+  created: number;
+  destroyed: number;
+  hibernated: number;
+  create_success: number;
+  create_failure: number;
+  create_success_rate: number;
+  avg_lifetime_hours: number;
+  by_platform: Record<string, number>;
+  by_cluster_type: Record<string, number>;
+  by_status: Record<string, number>;
+}
+
+export interface UsageReport {
+  start_date: string;
+  end_date: string;
+  generated_at: string;
+  cost: UsageCostSummary;
+  profiles: ProfileUsage[];
+  users: UserUsage[];
+  lifecycle: LifecycleStats;
+}
+
+export const reportsApi = {
+  getUsageReport: async (startDate: string, endDate: string): Promise<UsageReport> => {
+    const params = new URLSearchParams({ start_date: startDate, end_date: endDate });
+    return apiClient.get<UsageReport>(`/admin/reports/usage?${params.toString()}`);
+  },
+};

--- a/web/lib/hooks/useUsageReport.ts
+++ b/web/lib/hooks/useUsageReport.ts
@@ -1,0 +1,13 @@
+import { useQuery } from "@tanstack/react-query";
+import { reportsApi } from "../api/endpoints/reports";
+
+// useUsageReport fetches the platform-wide usage report for a date range.
+// Enabled only once both dates are set.
+export function useUsageReport(startDate: string, endDate: string) {
+  return useQuery({
+    queryKey: ["usage-report", startDate, endDate],
+    queryFn: () => reportsApi.getUsageReport(startDate, endDate),
+    enabled: Boolean(startDate) && Boolean(endDate),
+    staleTime: 5 * 60 * 1000, // 5 minutes
+  });
+}

--- a/web/lib/reports/exportPdf.ts
+++ b/web/lib/reports/exportPdf.ts
@@ -1,0 +1,121 @@
+import { jsPDF } from "jspdf";
+import autoTable from "jspdf-autotable";
+import type { UsageReport } from "@/lib/api/endpoints/reports";
+import { formatCurrency } from "@/lib/utils/formatters";
+
+// exportUsageReportPdf builds a data-driven (text-selectable) PDF from a usage
+// report. Not a screenshot — each section is rendered as a jspdf-autotable so
+// the output stays crisp and copy-pasteable.
+export function exportUsageReportPdf(report: UsageReport) {
+  const doc = new jsPDF({ orientation: "portrait", unit: "pt", format: "a4" });
+  const marginX = 40;
+  let y = 48;
+
+  doc.setFontSize(18);
+  doc.text("ocpctl Usage Report", marginX, y);
+  y += 22;
+
+  doc.setFontSize(10);
+  doc.setTextColor(100);
+  doc.text(
+    `Range: ${report.start_date} to ${report.end_date}   •   Generated: ${new Date(
+      report.generated_at
+    ).toLocaleString()}`,
+    marginX,
+    y
+  );
+  doc.setTextColor(0);
+  y += 24;
+
+  // Summary block
+  const summaryBody: string[][] = [
+    ["Total estimated cost", formatCurrency(report.cost.total_cost)],
+  ];
+  if (report.cost.prior_period_comparison) {
+    const cmp = report.cost.prior_period_comparison;
+    summaryBody.push([
+      "Prior period cost",
+      `${formatCurrency(cmp.previous_period)} (${
+        cmp.percent_change >= 0 ? "+" : ""
+      }${cmp.percent_change.toFixed(1)}%)`,
+    ]);
+  }
+  autoTable(doc, {
+    startY: y,
+    head: [["Summary", ""]],
+    body: [
+      ...summaryBody,
+      ["Total runtime hours", report.cost.total_runtime_hours.toFixed(1)],
+      ["Clusters active", String(report.cost.clusters_active)],
+      ["Clusters created", String(report.lifecycle.created)],
+      ["Clusters destroyed", String(report.lifecycle.destroyed)],
+      ["Clusters hibernated", String(report.lifecycle.hibernated)],
+      [
+        "Create success rate",
+        `${(report.lifecycle.create_success_rate * 100).toFixed(1)}% (${
+          report.lifecycle.create_success
+        }/${report.lifecycle.create_success + report.lifecycle.create_failure})`,
+      ],
+      ["Avg cluster lifetime (hrs)", report.lifecycle.avg_lifetime_hours.toFixed(1)],
+    ],
+    theme: "striped",
+    headStyles: { fillColor: [30, 41, 59] },
+    margin: { left: marginX, right: marginX },
+  });
+
+  // Most used profiles
+  autoTable(doc, {
+    startY: (doc as any).lastAutoTable.finalY + 20,
+    head: [["Most Used Profiles", "Clusters", "Runtime hrs", "Est. cost"]],
+    body: report.profiles.map((p) => [
+      p.profile,
+      String(p.cluster_count),
+      p.runtime_hours.toFixed(1),
+      formatCurrency(p.estimated_cost),
+    ]),
+    theme: "striped",
+    headStyles: { fillColor: [30, 41, 59] },
+    margin: { left: marginX, right: marginX },
+  });
+
+  // Most active users
+  autoTable(doc, {
+    startY: (doc as any).lastAutoTable.finalY + 20,
+    head: [["Most Active Users", "Clusters", "Runtime hrs", "Est. cost"]],
+    body: report.users.map((u) => [
+      u.owner,
+      String(u.cluster_count),
+      u.runtime_hours.toFixed(1),
+      formatCurrency(u.estimated_cost),
+    ]),
+    theme: "striped",
+    headStyles: { fillColor: [30, 41, 59] },
+    margin: { left: marginX, right: marginX },
+  });
+
+  // Breakdowns
+  const breakdownRows = (m: Record<string, number>) =>
+    Object.entries(m)
+      .sort((a, b) => b[1] - a[1])
+      .map(([k, v]) => [k, String(v)]);
+
+  autoTable(doc, {
+    startY: (doc as any).lastAutoTable.finalY + 20,
+    head: [["Platform", "Clusters"]],
+    body: breakdownRows(report.lifecycle.by_platform),
+    theme: "striped",
+    headStyles: { fillColor: [30, 41, 59] },
+    margin: { left: marginX, right: marginX },
+  });
+
+  autoTable(doc, {
+    startY: (doc as any).lastAutoTable.finalY + 20,
+    head: [["Cluster Type", "Clusters"]],
+    body: breakdownRows(report.lifecycle.by_cluster_type),
+    theme: "striped",
+    headStyles: { fillColor: [30, 41, 59] },
+    margin: { left: marginX, right: marginX },
+  });
+
+  doc.save(`usage-report_${report.start_date}_${report.end_date}.pdf`);
+}

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -32,6 +32,8 @@
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.1.0",
         "date-fns": "^3.6.0",
+        "jspdf": "^4.2.1",
+        "jspdf-autotable": "^5.0.8",
         "lucide-react": "^0.454.0",
         "next": "^14.2.0",
         "react": "^18.3.0",
@@ -4150,11 +4152,24 @@
         "undici-types": "~6.21.0"
       }
     },
+    "node_modules/@types/pako": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@types/pako/-/pako-2.0.4.tgz",
+      "integrity": "sha512-VWDCbrLeVXJM9fihYodcLiIv0ku+AlOa/TQ1SvYOaBuyrSKgEcro95LJyIsJ4vSo6BXIxOKxiJAat04CmST9Fw==",
+      "license": "MIT"
+    },
     "node_modules/@types/prop-types": {
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
       "license": "MIT"
+    },
+    "node_modules/@types/raf": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/@types/raf/-/raf-3.4.3.tgz",
+      "integrity": "sha512-c4YAvMedbPZ5tEyxzQdMoOhhJ4RD3rngZIdwC2/qDN3d7JpEhB6fiBRKVY1lg5B7Wk+uPBjn5f39j1/2MY1oOw==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@types/react": {
       "version": "18.3.28",
@@ -4175,6 +4190,13 @@
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@types/unist": {
       "version": "3.0.3",
@@ -5129,6 +5151,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/base64-arraybuffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
+      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.0",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.0.tgz",
@@ -5320,6 +5352,26 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/canvg": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/canvg/-/canvg-3.0.11.tgz",
+      "integrity": "sha512-5ON+q7jCTgMp9cjpu4Jo6XbvfYwSB2Ow3kzHKfIyJfaCAOHLbdKPQqGKgfED/R5B+3TFFfe8pegYA+b423SRyA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "@types/raf": "^3.4.0",
+        "core-js": "^3.8.3",
+        "raf": "^3.4.1",
+        "regenerator-runtime": "^0.13.7",
+        "rgbcolor": "^1.0.1",
+        "stackblur-canvas": "^2.0.0",
+        "svg-pathdata": "^6.0.3"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/ccount": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
@@ -5499,6 +5551,21 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/core-js": {
+      "version": "3.50.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.50.0.tgz",
+      "integrity": "sha512-BRWgOLKkFeCgRudR6zrs8p9XJZcE14grzKMMssoYrk6krtuEZ7MTKPIY5RzOnqsEKIR9kst7wNzphttraT+Yqw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -5512,6 +5579,16 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/css-line-break": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-2.1.0.tgz",
+      "integrity": "sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "utrie": "^1.0.2"
       }
     },
     "node_modules/cssesc": {
@@ -5867,6 +5944,16 @@
       "dependencies": {
         "@babel/runtime": "^7.8.7",
         "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/dompurify": {
+      "version": "3.4.14",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.14.tgz",
+      "integrity": "sha512-dVoH9z+MY+C9IilgGCk3YfFqjLi3fChm2OiKJMzh6axrJ5qwxqWaZamgmHrpv22CN/KdbZJuGEGgfQoL00LTdg==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optional": true,
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/dunder-proto": {
@@ -6653,6 +6740,17 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-png": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/fast-png/-/fast-png-6.4.0.tgz",
+      "integrity": "sha512-kAqZq1TlgBjZcLr5mcN6NP5Rv4V2f22z00c3g8vRrwkcqjerx7BEhPbOnWCPqaHUl2XWQBJQvOT/FQhdMT7X/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/pako": "^2.0.3",
+        "iobuffer": "^5.3.2",
+        "pako": "^2.1.0"
+      }
+    },
     "node_modules/fast-xml-parser": {
       "version": "5.3.6",
       "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.3.6.tgz",
@@ -6680,6 +6778,12 @@
       "dependencies": {
         "reusify": "^1.0.4"
       }
+    },
+    "node_modules/fflate": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
+      "license": "MIT"
     },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",
@@ -7315,6 +7419,20 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/html2canvas": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
+      "integrity": "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "css-line-break": "^2.1.0",
+        "text-segmentation": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -7400,6 +7518,12 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/iobuffer": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/iobuffer/-/iobuffer-5.4.0.tgz",
+      "integrity": "sha512-DRebOWuqDvxunfkNJAlc3IzWIPD5xVxwUNbHr7xKB8E6aLJxIPfNX3CoMJghcFjpv6RWQsrcJbghtEwSPoJqMA==",
+      "license": "MIT"
     },
     "node_modules/is-alphabetical": {
       "version": "2.0.1",
@@ -8004,6 +8128,32 @@
       },
       "bin": {
         "json5": "lib/cli.js"
+      }
+    },
+    "node_modules/jspdf": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-4.2.1.tgz",
+      "integrity": "sha512-YyAXyvnmjTbR4bHQRLzex3CuINCDlQnBqoSYyjJwTP2x9jDLuKDzy7aKUl0hgx3uhcl7xzg32agn5vlie6HIlQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.28.6",
+        "fast-png": "^6.2.0",
+        "fflate": "^0.8.1"
+      },
+      "optionalDependencies": {
+        "canvg": "^3.0.11",
+        "core-js": "^3.6.0",
+        "dompurify": "^3.3.1",
+        "html2canvas": "^1.0.0-rc.5"
+      }
+    },
+    "node_modules/jspdf-autotable": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/jspdf-autotable/-/jspdf-autotable-5.0.8.tgz",
+      "integrity": "sha512-Hy05N86yBO7CXBrnSLOge7i1ZYpKH2DjQ94iybaP7vBhSInjvRBgDc99ngKzSbSO8Jc98ZCally8I6n0tj2RJQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "jspdf": "^2 || ^3 || ^4"
       }
     },
     "node_modules/jsx-ast-utils": {
@@ -9468,6 +9618,22 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/pako": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-2.2.0.tgz",
+      "integrity": "sha512-zJq6RP/5q+TO2OpFV3FHzlPnFjmkb7Nc99a5SNjJE+uu/PkpChs+NIZSSzbBoD+6kjiISXjfYdwj1ZRQ81dz/w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -9571,6 +9737,13 @@
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
+    },
+    "node_modules/performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -9845,6 +10018,16 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/raf": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
+      "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "performance-now": "^2.1.0"
+      }
     },
     "node_modules/react": {
       "version": "18.3.1",
@@ -10128,6 +10311,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/regenerator-runtime": {
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.4",
       "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
@@ -10280,6 +10470,16 @@
       "engines": {
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rgbcolor": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/rgbcolor/-/rgbcolor-1.0.1.tgz",
+      "integrity": "sha512-9aZLIrhRaD97sgVhtJOW6ckOEh6/GnvQtdVNfdZ6s67+3/XwLS9lBcQYzEEhYVeUowN7pRzMLsyGhK2i/xvWbw==",
+      "license": "MIT OR SEE LICENSE IN FEEL-FREE.md",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.8.15"
       }
     },
     "node_modules/rimraf": {
@@ -10618,6 +10818,16 @@
       "integrity": "sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/stackblur-canvas": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/stackblur-canvas/-/stackblur-canvas-2.7.0.tgz",
+      "integrity": "sha512-yf7OENo23AGJhBriGx0QivY5JP6Y1HbrrDI6WLt6C5auYZXlQrheoY8hD4ibekFKz1HOfE48Ww8kMWMnJD/zcQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.1.14"
+      }
     },
     "node_modules/stop-iteration-iterator": {
       "version": "1.1.0",
@@ -10990,6 +11200,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/svg-pathdata": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/svg-pathdata/-/svg-pathdata-6.0.3.tgz",
+      "integrity": "sha512-qsjeeq5YjBZ5eMdFuUa4ZosMLxgr5RZ+F+Y1OrDhuOCEInRMA3x74XdBtggJcj9kOeInz0WE+LgCPDkZFlBYJw==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/tabbable": {
       "version": "6.4.0",
       "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.4.0.tgz",
@@ -11052,6 +11272,16 @@
       "license": "MIT",
       "peerDependencies": {
         "tailwindcss": ">=3.0.0 || insiders"
+      }
+    },
+    "node_modules/text-segmentation": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz",
+      "integrity": "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "utrie": "^1.0.2"
       }
     },
     "node_modules/text-table": {
@@ -11575,6 +11805,16 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/utrie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/utrie/-/utrie-1.0.2.tgz",
+      "integrity": "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "base64-arraybuffer": "^1.0.2"
+      }
     },
     "node_modules/vfile": {
       "version": "6.0.3",

--- a/web/package.json
+++ b/web/package.json
@@ -33,6 +33,8 @@
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.0",
     "date-fns": "^3.6.0",
+    "jspdf": "^4.2.1",
+    "jspdf-autotable": "^5.0.8",
     "lucide-react": "^0.454.0",
     "next": "^14.2.0",
     "react": "^18.3.0",


### PR DESCRIPTION
## Summary
Adds an admin-only **Usage Report** — an adhoc, date-ranged view of platform usage that can be downloaded as a PDF.

New endpoint `GET /api/v1/admin/reports/usage?start_date&end_date` returns a single `UsageReport` with four sections:
- **Cost estimation** — total estimated spend + prior-period comparison
- **Most used profiles** — ranked by cluster count over the range
- **Most active users** — ranked by estimated cost over the range
- **Cluster lifecycle stats** — created/destroyed/hibernated counts, avg lifetime, create success rate, and platform/type/status breakdowns

Computed live from existing tables (`clusters`, `jobs`) — no new table or migration.

## Backend
- Extracted the hibernation-aware, period-intersection cost math out of `handler_teams.go` into a shared, stateless `internal/cost` package (`EffectiveHourlyCost`, `PeriodCost`); `TeamHandler` now delegates to it (behavior-preserving).
- New `ReportStore` (`GetClustersActiveInRange`, `GetJobStatsInRange`) registered on the central `Store`.
- New `ReportHandler.GetUsageReport` — batch owner-email resolution (no N+1), `registry.GetAny` so disabled profiles still cost, and a separate prior-period query so current-window counts stay accurate.
- Route registered under the existing admin group (admin-only).

## Frontend
- New `/admin/usage-report` page: preset buttons (7/30/90 days, this month, this quarter) + custom range, Tremor bar charts/tables, summary cards (with ▲/▼ vs prior period), platform/type/status breakdowns.
- Client-side, data-driven (text-selectable) PDF export via `jspdf` + `jspdf-autotable`.
- Sidebar entry added to the admin nav.

## Tests
- `internal/cost`: table-driven `EffectiveHourlyCost` + `PeriodCost` (inside/clamped/outside window).
- `internal/api`: `buildLifecycleStats` unit tests; handler bad-range -> 400 (no DB needed); happy-path shape (self-skips until a test DB harness exists).

## Verification
- `go build ./...`, `go test -race ./...` pass.
- Deployed to **dev** (`v0.20260822.c5505f5`): API returns 401 on the new admin route (registered/gated), web page live.

## Notes
- Unrelated `scripts/deploy.sh` working-tree change is intentionally left out of this PR.
- `npm audit` reports 6 pre-existing/transitive vulnerabilities in web deps — not addressed here.