### PR TITLE
Fix DESTROYED clusters with NULL destroyed_at inflating usage reports

### DIFF
--- a/internal/cost/estimate.go
+++ b/internal/cost/estimate.go
@@ -49,6 +49,15 @@ func EffectiveHourlyCost(cluster *types.Cluster, prof *profile.Profile) float64 
 // (CreatedAt .. DestroyedAt/now) with the window; a cluster that was not active
 // during the window contributes zero cost and zero hours.
 func PeriodCost(cluster *types.Cluster, effectiveCost float64, periodStart, periodEnd time.Time) (float64, float64) {
+	// A destroyed cluster with no destroyed_at timestamp cannot be proven active
+	// during any window. Treat it as contributing nothing rather than assuming it
+	// is "still running" (which would project it through the window end and bill
+	// it forever). This guards against legacy rows whose destroy path failed to
+	// stamp destroyed_at.
+	if cluster.Status == types.ClusterStatusDestroyed && cluster.DestroyedAt == nil {
+		return 0.0, 0.0
+	}
+
 	// Determine cluster's active period within the date range
 	clusterStart := cluster.CreatedAt
 	clusterEnd := periodEnd // Assume still running

--- a/internal/cost/estimate_test.go
+++ b/internal/cost/estimate_test.go
@@ -92,4 +92,20 @@ func TestPeriodCost(t *testing.T) {
 			t.Fatalf("cost/hours = %v/%v, want 0/0", cost, hours)
 		}
 	})
+
+	// A DESTROYED cluster with no destroyed_at must not be projected as
+	// "still running" through the window end (the legacy zombie-row bug that
+	// inflated usage reports).
+	t.Run("destroyed without timestamp returns zero", func(t *testing.T) {
+		created := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC) // created before window
+		cl := &types.Cluster{
+			Status:      types.ClusterStatusDestroyed,
+			CreatedAt:   created,
+			DestroyedAt: nil,
+		}
+		cost, hours := PeriodCost(cl, 1.0, winStart, winEnd)
+		if cost != 0 || hours != 0 {
+			t.Fatalf("cost/hours = %v/%v, want 0/0", cost, hours)
+		}
+	})
 }

--- a/internal/store/report.go
+++ b/internal/store/report.go
@@ -19,6 +19,11 @@ type ReportStore struct {
 // before the end of the window and was either not yet destroyed or destroyed on
 // or after the start of the window.
 //
+// A cluster whose status is DESTROYED but whose destroyed_at is NULL is excluded:
+// it is gone, we just cannot prove when, so it must not be treated as an
+// indefinitely-running cluster that overlaps every window. (See the destroy-path
+// fast paths that historically set status without stamping destroyed_at.)
+//
 // Only the columns needed by the usage report are selected; the rest of the
 // Cluster struct is left zero-valued.
 func (s *ReportStore) GetClustersActiveInRange(ctx context.Context, start, end time.Time) ([]*types.Cluster, error) {
@@ -27,7 +32,10 @@ func (s *ReportStore) GetClustersActiveInRange(ctx context.Context, start, end t
 			owner, owner_id, team, status, created_at, destroyed_at
 		FROM clusters
 		WHERE created_at <= $2
-		  AND (destroyed_at IS NULL OR destroyed_at >= $1)
+		  AND (
+			destroyed_at >= $1
+			OR (destroyed_at IS NULL AND status <> 'DESTROYED')
+		  )
 		ORDER BY created_at DESC
 	`
 

--- a/internal/worker/handler_destroy.go
+++ b/internal/worker/handler_destroy.go
@@ -104,7 +104,7 @@ func (h *DestroyHandler) handleOpenShiftDestroy(ctx context.Context, job *types.
 			// Mark as DESTROYED to allow cleanup
 			if cluster.Status == types.ClusterStatusFailed {
 				log.Printf("Cluster %s failed during creation - no resources to destroy, marking as DESTROYED", cluster.Name)
-				if err := h.store.Clusters.UpdateStatus(ctx, nil, cluster.ID, types.ClusterStatusDestroyed); err != nil {
+				if err := h.store.Clusters.MarkDestroyed(ctx, cluster.ID); err != nil {
 					return fmt.Errorf("mark failed cluster as destroyed: %w", err)
 				}
 				return nil
@@ -121,7 +121,7 @@ func (h *DestroyHandler) handleOpenShiftDestroy(ctx context.Context, job *types.
 			// Mark as DESTROYED to allow cleanup
 			if cluster.Status == types.ClusterStatusFailed {
 				log.Printf("Cluster %s failed during creation - no artifacts found, marking as DESTROYED", cluster.Name)
-				if err := h.store.Clusters.UpdateStatus(ctx, nil, cluster.ID, types.ClusterStatusDestroyed); err != nil {
+				if err := h.store.Clusters.MarkDestroyed(ctx, cluster.ID); err != nil {
 					return fmt.Errorf("mark failed cluster as destroyed: %w", err)
 				}
 				return nil


### PR DESCRIPTION
## Problem
A cluster marked `status = DESTROYED` whose `destroyed_at` was never stamped was treated as **still running forever**:
- `GetClustersActiveInRange` matched it in **every** window (`destroyed_at IS NULL` branch).
- `PeriodCost` (estimate.go:57) only honors `destroyed_at` when `status==DESTROYED && DestroyedAt != nil`; with NULL it fell through to "assume still running" and billed the full window at full rate.

On prod this put **~$1,315 of phantom cost** into an unrelated 8/21–8/22 report: 3 `win-snap-*` Windows-snapshot-builder clusters (destroyed 2026-06-09, owner `system`) showing as `aws-virtualization-ga` ($1,307.51), plus one old `sanders-eks2` as `eks-minimal` ($7.20). Both rows were 100% phantom.

## Root cause
The normal/Azure/GCP destroy paths call `MarkDestroyed` (stamps `destroyed_at`). Only the two OpenShift "failed cluster, no resources to destroy" fast paths (`handler_destroy.go:107,124`) used `UpdateStatus(...Destroyed)`, which sets status but not `destroyed_at`.

## Fixes
1. **`cost.PeriodCost`** — a DESTROYED cluster with no `destroyed_at` contributes zero cost/hours instead of projecting as still-running. Guards the shared team-costs path too.
2. **`store.GetClustersActiveInRange`** — excludes DESTROYED rows with NULL `destroyed_at` (`destroyed_at >= start OR (destroyed_at IS NULL AND status <> 'DESTROYED')`), so zombies never load as active.
3. **Destroy path** — the two OpenShift fast paths now call `MarkDestroyed`, so newly-destroyed failed clusters can't become zombies.

## Data backfill (already applied to prod)
The 4 existing zombie rows were backfilled with `destroyed_at = updated_at` (their terminal `updated_at`, set by the destroy path). Post-fix the 8/21–8/22 window correctly shows 8 profiles and 0 remaining zombies. Since the report computes live, prod is already accurate.

## Tests
- `cost`: added `PeriodCost` "destroyed without timestamp returns zero".
- `go build ./...`, `go test ./internal/cost/... ./internal/api/... ./internal/worker/...` pass.

## Notes
- Unrelated `scripts/deploy.sh` working-tree change intentionally excluded.