### PR TITLE
Usage report: lifecycle metric fixes + per-profile drill-down

### DIFF
--- a/internal/api/handler_reports.go
+++ b/internal/api/handler_reports.go
@@ -126,6 +126,20 @@ func (h *ReportHandler) GetUsageReport(c echo.Context) error {
 		if u := usersByID[cl.OwnerID]; u != nil && u.Email != "" {
 			ownerKey = u.Email
 		}
+
+		// Per-cluster drill-down detail behind the profile aggregate.
+		pu.Clusters = append(pu.Clusters, types.ClusterUsage{
+			Name:          cl.Name,
+			Owner:         ownerKey,
+			Region:        cl.Region,
+			Status:        string(cl.Status),
+			ClusterType:   string(cl.ClusterType),
+			CreatedAt:     cl.CreatedAt,
+			DestroyedAt:   cl.DestroyedAt,
+			RuntimeHours:  clusterHours,
+			EstimatedCost: clusterCost,
+		})
+
 		uu := userAgg[ownerKey]
 		if uu == nil {
 			uu = &types.UserUsage{Owner: ownerKey}
@@ -162,6 +176,9 @@ func (h *ReportHandler) GetUsageReport(c echo.Context) error {
 	// Sort profiles by cluster count desc, users by estimated cost desc.
 	profiles := make([]types.ProfileUsage, 0, len(profileAgg))
 	for _, pu := range profileAgg {
+		sort.Slice(pu.Clusters, func(i, j int) bool {
+			return pu.Clusters[i].EstimatedCost > pu.Clusters[j].EstimatedCost
+		})
 		profiles = append(profiles, *pu)
 	}
 	sort.Slice(profiles, func(i, j int) bool {

--- a/internal/api/handler_reports.go
+++ b/internal/api/handler_reports.go
@@ -135,8 +135,11 @@ func (h *ReportHandler) GetUsageReport(c echo.Context) error {
 		uu.RuntimeHours += clusterHours
 		uu.EstimatedCost += clusterCost
 
-		// Average lifetime (over clusters active in-window)
-		lifeEnd := end
+		// Average lifetime (over clusters active in-window). Cap still-running
+		// clusters at the current time, not the window end: the window end may be
+		// in the future (end-of-day today) or, for a past-dated range, long before
+		// now — either way it does not reflect a cluster's real age.
+		lifeEnd := now
 		if cl.Status == types.ClusterStatusDestroyed && cl.DestroyedAt != nil {
 			lifeEnd = *cl.DestroyedAt
 		}

--- a/pkg/types/report.go
+++ b/pkg/types/report.go
@@ -24,12 +24,28 @@ type UsageCostSummary struct {
 	PriorPeriodComparison *PeriodComparison `json:"prior_period_comparison,omitempty"` // vs. the equally-sized preceding window
 }
 
-// ProfileUsage aggregates usage for a single profile within the window.
+// ProfileUsage aggregates usage for a single profile within the window. Clusters
+// holds the individual clusters that make up the aggregate, for drill-down.
 type ProfileUsage struct {
-	Profile       string  `json:"profile"`
-	ClusterCount  int     `json:"cluster_count"`
-	RuntimeHours  float64 `json:"runtime_hours"`
-	EstimatedCost float64 `json:"estimated_cost"`
+	Profile       string         `json:"profile"`
+	ClusterCount  int            `json:"cluster_count"`
+	RuntimeHours  float64        `json:"runtime_hours"`
+	EstimatedCost float64        `json:"estimated_cost"`
+	Clusters      []ClusterUsage `json:"clusters"` // per-cluster detail, sorted by est. cost desc
+}
+
+// ClusterUsage is the per-cluster detail behind an aggregate row, with the
+// cluster's runtime and estimated cost over the report window.
+type ClusterUsage struct {
+	Name          string     `json:"name"`
+	Owner         string     `json:"owner"` // email when resolvable, else owner_id
+	Region        string     `json:"region"`
+	Status        string     `json:"status"`
+	ClusterType   string     `json:"cluster_type"`
+	CreatedAt     time.Time  `json:"created_at"`
+	DestroyedAt   *time.Time `json:"destroyed_at,omitempty"`
+	RuntimeHours  float64    `json:"runtime_hours"`
+	EstimatedCost float64    `json:"estimated_cost"`
 }
 
 // UserUsage aggregates usage for a single owner within the window.

--- a/web/app/(dashboard)/admin/usage-report/page.tsx
+++ b/web/app/(dashboard)/admin/usage-report/page.tsx
@@ -129,20 +129,28 @@ export default function UsageReportPage() {
             <SummaryCard
               title="Clusters active"
               value={String(report.cost.clusters_active)}
-              subtitle={`${report.lifecycle.created} created · ${report.lifecycle.destroyed} destroyed`}
+              subtitle={`${report.lifecycle.created} created · ${report.lifecycle.destroyed} destroyed in range`}
             />
             <SummaryCard
               title="Avg lifetime"
               value={`${report.lifecycle.avg_lifetime_hours.toFixed(1)} hrs`}
-              subtitle={`${report.lifecycle.hibernated} hibernated`}
+              subtitle={`${report.lifecycle.by_status?.HIBERNATED ?? 0} currently hibernated`}
             />
-            <SummaryCard
-              title="Create success rate"
-              value={`${(report.lifecycle.create_success_rate * 100).toFixed(0)}%`}
-              subtitle={`${report.lifecycle.create_success}/${
-                report.lifecycle.create_success + report.lifecycle.create_failure
-              } jobs`}
-            />
+            {(() => {
+              const completed =
+                report.lifecycle.create_success + report.lifecycle.create_failure;
+              return (
+                <SummaryCard
+                  title="Create success rate"
+                  value={completed > 0 ? `${(report.lifecycle.create_success_rate * 100).toFixed(0)}%` : "—"}
+                  subtitle={
+                    completed > 0
+                      ? `${report.lifecycle.create_success}/${completed} create jobs in range`
+                      : "no create jobs in range"
+                  }
+                />
+              );
+            })()}
           </div>
 
           {/* Most used profiles */}

--- a/web/app/(dashboard)/admin/usage-report/page.tsx
+++ b/web/app/(dashboard)/admin/usage-report/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { Fragment, useState } from "react";
 import { format, subDays, startOfMonth, startOfQuarter } from "date-fns";
 import { useUsageReport } from "@/lib/hooks/useUsageReport";
 import { exportUsageReportPdf } from "@/lib/reports/exportPdf";
@@ -18,7 +18,8 @@ import {
 } from "@/components/ui/table";
 import { formatCurrency } from "@/lib/utils/formatters";
 import { BarChart } from "@tremor/react";
-import { Download, FileText } from "lucide-react";
+import { Download, FileText, ChevronRight, ChevronDown } from "lucide-react";
+import type { ProfileUsage } from "@/lib/api/endpoints/reports";
 
 const fmt = (d: Date) => format(d, "yyyy-MM-dd");
 
@@ -171,12 +172,7 @@ export default function UsageReportPage() {
                   className="h-64"
                 />
               )}
-              <UsageTable
-                rows={report.profiles}
-                nameHeader="Profile"
-                nameKey="profile"
-                emptyText="No profiles in range"
-              />
+              <ProfileTable profiles={report.profiles} />
             </CardContent>
           </Card>
 
@@ -279,6 +275,98 @@ function UsageTable({
             <TableCell className="text-right">{formatCurrency(r.estimated_cost)}</TableCell>
           </TableRow>
         ))}
+      </TableBody>
+    </Table>
+  );
+}
+
+function ProfileTable({ profiles }: { profiles: ProfileUsage[] }) {
+  const [expanded, setExpanded] = useState<Record<string, boolean>>({});
+
+  if (profiles.length === 0) {
+    return <p className="text-sm text-muted-foreground">No profiles in range</p>;
+  }
+
+  const toggle = (key: string) =>
+    setExpanded((prev) => ({ ...prev, [key]: !prev[key] }));
+
+  return (
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableHead>Profile</TableHead>
+          <TableHead className="text-right">Clusters</TableHead>
+          <TableHead className="text-right">Runtime hrs</TableHead>
+          <TableHead className="text-right">Est. cost</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {profiles.map((p) => {
+          const key = p.profile || "unknown";
+          const isOpen = !!expanded[key];
+          return (
+            <Fragment key={key}>
+              <TableRow
+                className="cursor-pointer"
+                onClick={() => toggle(key)}
+              >
+                <TableCell className="font-medium">
+                  <span className="inline-flex items-center gap-1">
+                    {isOpen ? (
+                      <ChevronDown className="h-4 w-4 text-muted-foreground" />
+                    ) : (
+                      <ChevronRight className="h-4 w-4 text-muted-foreground" />
+                    )}
+                    {p.profile}
+                  </span>
+                </TableCell>
+                <TableCell className="text-right">{p.cluster_count}</TableCell>
+                <TableCell className="text-right">{p.runtime_hours.toFixed(1)}</TableCell>
+                <TableCell className="text-right">{formatCurrency(p.estimated_cost)}</TableCell>
+              </TableRow>
+              {isOpen && (
+                <TableRow className="hover:bg-transparent">
+                  <TableCell colSpan={4} className="bg-muted/30 p-0">
+                    <div className="p-3">
+                      <Table>
+                        <TableHeader>
+                          <TableRow>
+                            <TableHead>Cluster</TableHead>
+                            <TableHead>Owner</TableHead>
+                            <TableHead>Region</TableHead>
+                            <TableHead>Status</TableHead>
+                            <TableHead>Created</TableHead>
+                            <TableHead className="text-right">Runtime hrs</TableHead>
+                            <TableHead className="text-right">Est. cost</TableHead>
+                          </TableRow>
+                        </TableHeader>
+                        <TableBody>
+                          {p.clusters.map((c) => (
+                            <TableRow key={c.name}>
+                              <TableCell className="font-medium">{c.name}</TableCell>
+                              <TableCell>{c.owner || "—"}</TableCell>
+                              <TableCell>{c.region || "—"}</TableCell>
+                              <TableCell>{c.status}</TableCell>
+                              <TableCell>
+                                {format(new Date(c.created_at), "MMM d, yyyy")}
+                              </TableCell>
+                              <TableCell className="text-right">
+                                {c.runtime_hours.toFixed(1)}
+                              </TableCell>
+                              <TableCell className="text-right">
+                                {formatCurrency(c.estimated_cost)}
+                              </TableCell>
+                            </TableRow>
+                          ))}
+                        </TableBody>
+                      </Table>
+                    </div>
+                  </TableCell>
+                </TableRow>
+              )}
+            </Fragment>
+          );
+        })}
       </TableBody>
     </Table>
   );

--- a/web/lib/api/endpoints/reports.ts
+++ b/web/lib/api/endpoints/reports.ts
@@ -15,11 +15,24 @@ export interface UsageCostSummary {
   };
 }
 
+export interface ClusterUsage {
+  name: string;
+  owner: string;
+  region: string;
+  status: string;
+  cluster_type: string;
+  created_at: string;
+  destroyed_at?: string;
+  runtime_hours: number;
+  estimated_cost: number;
+}
+
 export interface ProfileUsage {
   profile: string;
   cluster_count: number;
   runtime_hours: number;
   estimated_cost: number;
+  clusters: ClusterUsage[];
 }
 
 export interface UserUsage {

--- a/web/lib/reports/exportPdf.ts
+++ b/web/lib/reports/exportPdf.ts
@@ -47,14 +47,16 @@ export function exportUsageReportPdf(report: UsageReport) {
       ...summaryBody,
       ["Total runtime hours", report.cost.total_runtime_hours.toFixed(1)],
       ["Clusters active", String(report.cost.clusters_active)],
-      ["Clusters created", String(report.lifecycle.created)],
-      ["Clusters destroyed", String(report.lifecycle.destroyed)],
-      ["Clusters hibernated", String(report.lifecycle.hibernated)],
+      ["Clusters created (in range)", String(report.lifecycle.created)],
+      ["Clusters destroyed (in range)", String(report.lifecycle.destroyed)],
+      ["Currently hibernated", String(report.lifecycle.by_status?.HIBERNATED ?? 0)],
       [
         "Create success rate",
-        `${(report.lifecycle.create_success_rate * 100).toFixed(1)}% (${
-          report.lifecycle.create_success
-        }/${report.lifecycle.create_success + report.lifecycle.create_failure})`,
+        report.lifecycle.create_success + report.lifecycle.create_failure > 0
+          ? `${(report.lifecycle.create_success_rate * 100).toFixed(1)}% (${
+              report.lifecycle.create_success
+            }/${report.lifecycle.create_success + report.lifecycle.create_failure})`
+          : "— (no create jobs in range)",
       ],
       ["Avg cluster lifetime (hrs)", report.lifecycle.avg_lifetime_hours.toFixed(1)],
     ],

--- a/web/lib/reports/exportPdf.ts
+++ b/web/lib/reports/exportPdf.ts
@@ -65,7 +65,7 @@ export function exportUsageReportPdf(report: UsageReport) {
     margin: { left: marginX, right: marginX },
   });
 
-  // Most used profiles
+  // Most used profiles (aggregate)
   autoTable(doc, {
     startY: (doc as any).lastAutoTable.finalY + 20,
     head: [["Most Used Profiles", "Clusters", "Runtime hrs", "Est. cost"]],
@@ -79,6 +79,27 @@ export function exportUsageReportPdf(report: UsageReport) {
     headStyles: { fillColor: [30, 41, 59] },
     margin: { left: marginX, right: marginX },
   });
+
+  // Per-profile drill-down: the clusters behind each aggregate row.
+  for (const p of report.profiles) {
+    if (!p.clusters || p.clusters.length === 0) continue;
+    autoTable(doc, {
+      startY: (doc as any).lastAutoTable.finalY + 16,
+      head: [[`Clusters — ${p.profile}`, "Owner", "Region", "Status", "Runtime hrs", "Est. cost"]],
+      body: p.clusters.map((c) => [
+        c.name,
+        c.owner || "—",
+        c.region || "—",
+        c.status,
+        c.runtime_hours.toFixed(1),
+        formatCurrency(c.estimated_cost),
+      ]),
+      theme: "grid",
+      styles: { fontSize: 8 },
+      headStyles: { fillColor: [71, 85, 105], fontSize: 8 },
+      margin: { left: marginX, right: marginX },
+    });
+  }
 
   // Most active users
   autoTable(doc, {


### PR DESCRIPTION
## Summary
Follow-ups to the usage report feature (#114) and the zombie-cluster fix (#115).

### 1. Lifecycle metric accuracy
Distinguishes **in-range churn** from **current state**, which was causing confusing numbers on short (single-day) ranges.
- **Avg lifetime cap at `now`** (`handler_reports.go`): still-running clusters are aged to the current time, not the window end (which can be in the future or far in the past for a back-dated range).
- **Relabel churn tiles as "in range"** and add a current-state **"currently hibernated"** figure from `by_status["HIBERNATED"]`.
- **Create success rate shows "—"** ("no create jobs in range") when there are zero create jobs, instead of a misleading 0%.

### 2. Per-profile cluster drill-down
Keeps the per-cluster detail the handler already computes (runtime + cost per cluster) instead of discarding it after summing.
- New `ClusterUsage` type on `ProfileUsage`, populated in the existing loop, sorted by est. cost desc. **No new query.**
- **Most Used Profiles** rows are now expandable → nested table of the clusters behind each aggregate (name, owner, region, status, created, runtime hrs, est. cost). Aggregate totals reconcile with the drill-down.
- **PDF export** gains a per-profile cluster sub-table under each aggregate.

## Testing
- `go build ./...`, `go test ./internal/cost/ ./internal/api/ ./internal/store/` — green
- `npx tsc --noEmit` (web) — clean