### PR TITLE
Recalibrate profile cost estimates to on-demand list prices

### DIFF
--- a/internal/cost/estimate.go
+++ b/internal/cost/estimate.go
@@ -32,8 +32,9 @@ func EffectiveHourlyCost(cluster *types.Cluster, prof *profile.Profile) float64 
 			// IKS: Workers scaled to 0, minimal cost (~5%)
 			return baseCost * 0.05
 		case types.ClusterTypeGKE:
-			// GKE: Node pools scaled to 0, no control plane cost, only persistent disks (~3%)
-			return baseCost * 0.03
+			// GKE Standard: node pools scaled to 0, but the $0.10/hr cluster
+			// management fee continues (plus a little for persistent disks).
+			return 0.10
 		default:
 			// Unknown cluster type, use conservative estimate
 			return baseCost * 0.10

--- a/internal/cost/estimate_test.go
+++ b/internal/cost/estimate_test.go
@@ -26,7 +26,7 @@ func TestEffectiveHourlyCost(t *testing.T) {
 		{"hibernated openshift 10pct", types.ClusterStatusHibernated, types.ClusterTypeOpenShift, 1.0, 0.10},
 		{"hibernated rosa fixed", types.ClusterStatusHibernated, types.ClusterTypeROSA, 1.0, 0.03},
 		{"hibernated eks fixed", types.ClusterStatusHibernated, types.ClusterTypeEKS, 1.0, 0.10},
-		{"hibernated gke 3pct", types.ClusterStatusHibernated, types.ClusterTypeGKE, 1.0, 0.03},
+		{"hibernated gke fixed mgmt fee", types.ClusterStatusHibernated, types.ClusterTypeGKE, 1.0, 0.10},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/profile/definitions/aks-standard.yaml
+++ b/internal/profile/definitions/aks-standard.yaml
@@ -46,8 +46,9 @@ tags:
 features:
   offHoursScaling: true
 costControls:
-  estimatedHourlyCost: 1.01
-  maxMonthlyCost: 730
+  # List-price basis: AKS: 3x D4s_v3 @0.192 + Std SLA 0.10 + net (East US on-demand)
+  estimatedHourlyCost: 0.73
+  maxMonthlyCost: 530
   budgetAlertThreshold: 0.8
   warningMessage: AKS Free tier has no control plane cost. Only compute billed.
 platformConfig:

--- a/internal/profile/definitions/aro-standard.yaml
+++ b/internal/profile/definitions/aro-standard.yaml
@@ -45,8 +45,9 @@ tags:
 features:
   offHoursScaling: true
 costControls:
-  estimatedHourlyCost: 3.7
-  maxMonthlyCost: 2664
+  # List-price basis: ARO: 3x D8s_v5 + 3x D4s_v6 + 3 infra + ARO service fee (East US)
+  estimatedHourlyCost: 3.0
+  maxMonthlyCost: 2190
   budgetAlertThreshold: 0.8
   warningMessage: ARO is a managed service with higher costs than self-managed.
 platformConfig:

--- a/internal/profile/definitions/aws-minimal-ga.yaml
+++ b/internal/profile/definitions/aws-minimal-ga.yaml
@@ -78,8 +78,9 @@ features:
   fipsMode: false
   privateCluster: false
 costControls:
-  estimatedHourlyCost: 2.5
-  maxMonthlyCost: 1800
+  # List-price basis: OCP IPI: 3x m6i.xlarge @0.192 (schedulable masters, 0 workers) + infra (us-east-1)
+  estimatedHourlyCost: 0.7
+  maxMonthlyCost: 510
   budgetAlertThreshold: 0.8
 platformConfig:
   aws:

--- a/internal/profile/definitions/aws-minimal-prerelease.yaml
+++ b/internal/profile/definitions/aws-minimal-prerelease.yaml
@@ -73,8 +73,9 @@ features:
   fipsMode: false
   privateCluster: false
 costControls:
-  estimatedHourlyCost: 2.5
-  maxMonthlyCost: 1800
+  # List-price basis: OCP IPI: 3x m6i.xlarge @0.192 (schedulable masters, 0 workers) + infra (us-east-1)
+  estimatedHourlyCost: 0.7
+  maxMonthlyCost: 510
   budgetAlertThreshold: 0.8
 platformConfig:
   aws:

--- a/internal/profile/definitions/aws-minimal-test.yaml
+++ b/internal/profile/definitions/aws-minimal-test.yaml
@@ -72,8 +72,9 @@ features:
   fipsMode: false
   privateCluster: false
 costControls:
-  estimatedHourlyCost: 2.5
-  maxMonthlyCost: 1800
+  # List-price basis: OCP IPI: 3x m6i.xlarge @0.192 (schedulable masters, 0 workers) + infra (us-east-1)
+  estimatedHourlyCost: 0.7
+  maxMonthlyCost: 510
   budgetAlertThreshold: 0.8
 platformConfig:
   aws:

--- a/internal/profile/definitions/aws-odf-ga.yaml
+++ b/internal/profile/definitions/aws-odf-ga.yaml
@@ -67,8 +67,9 @@ features:
   fipsMode: false
   privateCluster: false
 costControls:
-  estimatedHourlyCost: 3.60
-  maxMonthlyCost: 2592
+  # List-price basis: OCP+ODF: 3x m8i.2xlarge @0.48 + 3x m8i.4xlarge @0.97 + ODF storage (us-east-1)
+  estimatedHourlyCost: 4.85
+  maxMonthlyCost: 3540
   budgetAlertThreshold: 0.8
   warningMessage: 3x m8i.4xlarge + 3x m8i.2xlarge cost ~$3.60/hr ($2,592/month).
 platformConfig:

--- a/internal/profile/definitions/aws-odf-m6i-ga.yaml
+++ b/internal/profile/definitions/aws-odf-m6i-ga.yaml
@@ -79,8 +79,9 @@ features:
   fipsMode: false
   privateCluster: false
 costControls:
-  estimatedHourlyCost: 3.40
-  maxMonthlyCost: 2448
+  # List-price basis: OCP+ODF: 3x m6i.xlarge @0.192 + 3x m6i.4xlarge @0.768 + ODF storage (us-east-1)
+  estimatedHourlyCost: 3.4
+  maxMonthlyCost: 2480
   budgetAlertThreshold: 0.8
   warningMessage: 3x m6i.4xlarge + 3x m6i.xlarge cost ~$3.40/hr ($2,448/month).
 platformConfig:

--- a/internal/profile/definitions/aws-rhwa-lab-prerelease.yaml
+++ b/internal/profile/definitions/aws-rhwa-lab-prerelease.yaml
@@ -64,8 +64,9 @@ features:
   fipsMode: false
   privateCluster: false
 costControls:
-  estimatedHourlyCost: 0.77
-  maxMonthlyCost: 600
+  # List-price basis: OCP IPI: 3x m6i.xlarge @0.192 (0 workers) + infra (us-east-1)
+  estimatedHourlyCost: 0.7
+  maxMonthlyCost: 510
   budgetAlertThreshold: 0.8
 platformConfig:
   aws:

--- a/internal/profile/definitions/aws-rhwa-lab.yaml
+++ b/internal/profile/definitions/aws-rhwa-lab.yaml
@@ -64,8 +64,9 @@ features:
   fipsMode: false
   privateCluster: false
 costControls:
-  estimatedHourlyCost: 0.77
-  maxMonthlyCost: 600
+  # List-price basis: OCP IPI: 3x m6i.xlarge @0.192 (0 workers) + infra (us-east-1)
+  estimatedHourlyCost: 0.7
+  maxMonthlyCost: 510
   budgetAlertThreshold: 0.8
 platformConfig:
   aws:

--- a/internal/profile/definitions/aws-sno-422-test.yaml
+++ b/internal/profile/definitions/aws-sno-422-test.yaml
@@ -70,8 +70,9 @@ features:
   fipsMode: false
   privateCluster: false
 costControls:
-  estimatedHourlyCost: 1.6
-  maxMonthlyCost: 1152
+  # List-price basis: OCP SNO: 1x m6i.4xlarge @0.768 + infra (us-east-1)
+  estimatedHourlyCost: 0.87
+  maxMonthlyCost: 640
   budgetAlertThreshold: 0.8
 platformConfig:
   aws:

--- a/internal/profile/definitions/aws-sno-ga.yaml
+++ b/internal/profile/definitions/aws-sno-ga.yaml
@@ -77,8 +77,9 @@ features:
   fipsMode: false
   privateCluster: false
 costControls:
-  estimatedHourlyCost: 0.8
-  maxMonthlyCost: 1728
+  # List-price basis: OCP SNO: 1x m6i.2xlarge @0.384 + infra (us-east-1)
+  estimatedHourlyCost: 0.48
+  maxMonthlyCost: 350
   budgetAlertThreshold: 0.8
 platformConfig:
   aws:

--- a/internal/profile/definitions/aws-sno-prerelease.yaml
+++ b/internal/profile/definitions/aws-sno-prerelease.yaml
@@ -74,8 +74,9 @@ features:
   fipsMode: false
   privateCluster: false
 costControls:
-  estimatedHourlyCost: 0.8
-  maxMonthlyCost: 576
+  # List-price basis: OCP SNO: 1x m6i.2xlarge @0.384 + infra (us-east-1)
+  estimatedHourlyCost: 0.48
+  maxMonthlyCost: 350
   budgetAlertThreshold: 0.8
 platformConfig:
   aws:

--- a/internal/profile/definitions/aws-sno-shared-vpc-custom.yaml
+++ b/internal/profile/definitions/aws-sno-shared-vpc-custom.yaml
@@ -58,8 +58,9 @@ features:
   fipsMode: false
   privateCluster: false
 costControls:
-  estimatedHourlyCost: 0.8
-  maxMonthlyCost: 576
+  # List-price basis: OCP SNO: 1x m6i.2xlarge @0.384 + infra (us-east-1)
+  estimatedHourlyCost: 0.48
+  maxMonthlyCost: 350
   budgetAlertThreshold: 0.8
 platformConfig:
   aws:

--- a/internal/profile/definitions/aws-sno-shared-vpc.yaml
+++ b/internal/profile/definitions/aws-sno-shared-vpc.yaml
@@ -74,8 +74,9 @@ features:
   fipsMode: false
   privateCluster: false
 costControls:
-  estimatedHourlyCost: 0.8
-  maxMonthlyCost: 576
+  # List-price basis: OCP SNO: 1x m6i.2xlarge @0.384 + infra (us-east-1)
+  estimatedHourlyCost: 0.48
+  maxMonthlyCost: 350
   budgetAlertThreshold: 0.8
 platformConfig:
   aws:

--- a/internal/profile/definitions/aws-sno-test.yaml
+++ b/internal/profile/definitions/aws-sno-test.yaml
@@ -74,8 +74,9 @@ features:
   fipsMode: false
   privateCluster: false
 costControls:
-  estimatedHourlyCost: 0.8
-  maxMonthlyCost: 576
+  # List-price basis: OCP SNO: 1x m6i.2xlarge @0.384 + infra (us-east-1)
+  estimatedHourlyCost: 0.48
+  maxMonthlyCost: 350
   budgetAlertThreshold: 0.8
 platformConfig:
   aws:

--- a/internal/profile/definitions/aws-standard-ga.yaml
+++ b/internal/profile/definitions/aws-standard-ga.yaml
@@ -78,8 +78,9 @@ features:
   fipsMode: false
   privateCluster: false
 costControls:
-  estimatedHourlyCost: 7.8
-  maxMonthlyCost: 5600
+  # List-price basis: OCP IPI: 3x m6i.xlarge @0.192 + 3x m6i.2xlarge @0.384 + infra (us-east-1)
+  estimatedHourlyCost: 1.98
+  maxMonthlyCost: 1450
   budgetAlertThreshold: 0.8
 platformConfig:
   aws:

--- a/internal/profile/definitions/aws-standard-prerelease.yaml
+++ b/internal/profile/definitions/aws-standard-prerelease.yaml
@@ -73,8 +73,9 @@ features:
   fipsMode: false
   privateCluster: false
 costControls:
-  estimatedHourlyCost: 7.8
-  maxMonthlyCost: 5600
+  # List-price basis: OCP IPI: 3x m6i.xlarge @0.192 + 3x m6i.2xlarge @0.384 + infra (us-east-1)
+  estimatedHourlyCost: 1.98
+  maxMonthlyCost: 1450
   budgetAlertThreshold: 0.8
 platformConfig:
   aws:

--- a/internal/profile/definitions/aws-standard.yaml
+++ b/internal/profile/definitions/aws-standard.yaml
@@ -74,8 +74,9 @@ features:
   fipsMode: false
   privateCluster: false
 costControls:
-  estimatedHourlyCost: 7.8
-  maxMonthlyCost: 5600
+  # List-price basis: OCP IPI: 3x m6i.xlarge @0.192 + 3x m6i.2xlarge @0.384 + infra (us-east-1)
+  estimatedHourlyCost: 1.98
+  maxMonthlyCost: 1450
   budgetAlertThreshold: 0.8
 platformConfig:
   aws:

--- a/internal/profile/definitions/aws-virt-windows-minimal-ga.yaml
+++ b/internal/profile/definitions/aws-virt-windows-minimal-ga.yaml
@@ -73,8 +73,9 @@ features:
   fipsMode: false
   privateCluster: false
 costControls:
-  estimatedHourlyCost: 9.08
-  maxMonthlyCost: 6538
+  # List-price basis: OCP virt: 3x m6i.xlarge @0.192 + 2x m5zn.metal @3.96 + infra (us-east-1)
+  estimatedHourlyCost: 8.8
+  maxMonthlyCost: 6420
   budgetAlertThreshold: 0.7
   warningMessage: 2x Metal instances cost $9.08/hr ($6,538/month). Enable work hours
     hibernation to reduce to ~$1,670/month.

--- a/internal/profile/definitions/aws-virt-windows-minimal-prerelease.yaml
+++ b/internal/profile/definitions/aws-virt-windows-minimal-prerelease.yaml
@@ -71,8 +71,9 @@ features:
   fipsMode: false
   privateCluster: false
 costControls:
-  estimatedHourlyCost: 9.08
-  maxMonthlyCost: 6538
+  # List-price basis: OCP virt: 3x m6i.xlarge @0.192 + 2x m5zn.metal @3.96 + infra (us-east-1)
+  estimatedHourlyCost: 8.8
+  maxMonthlyCost: 6420
   budgetAlertThreshold: 0.7
   warningMessage: 2x Metal instances cost $9.08/hr ($6,538/month). Enable work hours
     hibernation to reduce to ~$1,670/month.

--- a/internal/profile/definitions/aws-virt-windows-minimal.yaml
+++ b/internal/profile/definitions/aws-virt-windows-minimal.yaml
@@ -71,8 +71,9 @@ features:
   fipsMode: false
   privateCluster: false
 costControls:
-  estimatedHourlyCost: 9.08
-  maxMonthlyCost: 6538
+  # List-price basis: OCP virt: 3x m6i.xlarge @0.192 + 2x m5zn.metal @3.96 + infra (us-east-1)
+  estimatedHourlyCost: 8.8
+  maxMonthlyCost: 6420
   budgetAlertThreshold: 0.7
   warningMessage: 2x Metal instances cost $9.08/hr ($6,538/month). Enable work hours
     hibernation to reduce to ~$1,670/month.

--- a/internal/profile/definitions/aws-virtualization-ga.yaml
+++ b/internal/profile/definitions/aws-virtualization-ga.yaml
@@ -79,8 +79,9 @@ features:
   fipsMode: false
   privateCluster: false
 costControls:
-  estimatedHourlyCost: 9.08
-  maxMonthlyCost: 6538
+  # List-price basis: OCP virt: 3x m6i.xlarge @0.192 + 2x m5zn.metal @3.96 + infra (us-east-1)
+  estimatedHourlyCost: 8.8
+  maxMonthlyCost: 6420
   budgetAlertThreshold: 0.7
   warningMessage: 2x Metal instances cost $9.08/hr ($6,538/month). Enable work hours
     hibernation to reduce to ~$1,670/month.

--- a/internal/profile/definitions/aws-virtualization-prerelease.yaml
+++ b/internal/profile/definitions/aws-virtualization-prerelease.yaml
@@ -74,8 +74,9 @@ features:
   fipsMode: false
   privateCluster: false
 costControls:
-  estimatedHourlyCost: 9.08
-  maxMonthlyCost: 6538
+  # List-price basis: OCP virt: 3x m6i.xlarge @0.192 + 2x m5zn.metal @3.96 + infra (us-east-1)
+  estimatedHourlyCost: 8.8
+  maxMonthlyCost: 6420
   budgetAlertThreshold: 0.7
   warningMessage: 2x Metal instances cost $9.08/hr ($6,538/month). Enable work hours
     hibernation to reduce to ~$1,670/month.

--- a/internal/profile/definitions/aws-virtualization.yaml
+++ b/internal/profile/definitions/aws-virtualization.yaml
@@ -74,8 +74,9 @@ features:
   fipsMode: false
   privateCluster: false
 costControls:
-  estimatedHourlyCost: 35.5
-  maxMonthlyCost: 25500
+  # List-price basis: OCP virt: 3x m6i.2xlarge @0.384 + 3x m6i.metal @6.144 + infra (us-east-1)
+  estimatedHourlyCost: 20.1
+  maxMonthlyCost: 14670
   budgetAlertThreshold: 0.8
 platformConfig:
   aws:

--- a/internal/profile/definitions/azure-sno-ga.yaml
+++ b/internal/profile/definitions/azure-sno-ga.yaml
@@ -49,8 +49,9 @@ tags:
 features:
   offHoursScaling: true
 costControls:
-  estimatedHourlyCost: 0.67
-  maxMonthlyCost: 482
+  # List-price basis: OCP SNO: 1x D8s_v5 @0.384 + infra (East US)
+  estimatedHourlyCost: 0.48
+  maxMonthlyCost: 350
   budgetAlertThreshold: 0.8
   warningMessage: SNO cannot scale workers. Stop VM to reduce costs.
 platformConfig:

--- a/internal/profile/definitions/azure-standard.yaml
+++ b/internal/profile/definitions/azure-standard.yaml
@@ -53,8 +53,9 @@ tags:
 features:
   offHoursScaling: true
 costControls:
-  estimatedHourlyCost: 3.5
-  maxMonthlyCost: 2520
+  # List-price basis: OCP IPI: 3x D8s_v5 @0.384 + 3x D4s_v5 @0.192 + infra (East US)
+  estimatedHourlyCost: 1.98
+  maxMonthlyCost: 1450
   budgetAlertThreshold: 0.8
   warningMessage: Azure VMs billed per minute. Stop VMs to reduce costs.
 platformConfig:

--- a/internal/profile/definitions/eks-minimal.yaml
+++ b/internal/profile/definitions/eks-minimal.yaml
@@ -56,8 +56,9 @@ tags:
 features:
   oidcProvider: true
 costControls:
-  estimatedHourlyCost: 0.15
-  maxMonthlyCost: 110
+  # List-price basis: EKS: control plane 0.10 + 2x t3.medium @0.0416 (us-east-1)
+  estimatedHourlyCost: 0.23
+  maxMonthlyCost: 170
   budgetAlertThreshold: 0.8
 platformConfig:
   eks:

--- a/internal/profile/definitions/eks-standard.yaml
+++ b/internal/profile/definitions/eks-standard.yaml
@@ -55,8 +55,9 @@ tags:
 features:
   oidcProvider: true
 costControls:
-  estimatedHourlyCost: 0.56
-  maxMonthlyCost: 405
+  # List-price basis: EKS: control plane 0.10 + 4x t3.large @0.0832 (us-east-1)
+  estimatedHourlyCost: 0.48
+  maxMonthlyCost: 350
   budgetAlertThreshold: 0.8
 platformConfig:
   eks:

--- a/internal/profile/definitions/gcp-sno-ga.yaml
+++ b/internal/profile/definitions/gcp-sno-ga.yaml
@@ -69,8 +69,9 @@ features:
   fipsMode: false
   privateCluster: false
 costControls:
-  estimatedHourlyCost: 0.2
-  maxMonthlyCost: 175
+  # List-price basis: OCP SNO: 1x n2-standard-4 @0.189 + infra (us-central1)
+  estimatedHourlyCost: 0.27
+  maxMonthlyCost: 200
   budgetAlertThreshold: 0.8
   warningMessage: Single Node OpenShift on GCP. All workloads run on one n2-standard-4
     VM.

--- a/internal/profile/definitions/gcp-standard.yaml
+++ b/internal/profile/definitions/gcp-standard.yaml
@@ -70,8 +70,9 @@ features:
   fipsMode: false
   privateCluster: false
 costControls:
-  estimatedHourlyCost: 1.2
-  maxMonthlyCost: 900
+  # List-price basis: OCP IPI: 3x n2-standard-4 @0.189 + 3x n2-standard-8 @0.378 + infra (us-central1)
+  estimatedHourlyCost: 1.9
+  maxMonthlyCost: 1390
   budgetAlertThreshold: 0.8
   warningMessage: 'OpenShift on GCP uses GCE VMs. Control plane: n2-standard-4, Workers:
     n2-standard-8'

--- a/internal/profile/definitions/gke-standard.yaml
+++ b/internal/profile/definitions/gke-standard.yaml
@@ -54,11 +54,12 @@ tags:
 features:
   offHoursScaling: true
 costControls:
-  estimatedHourlyCost: 0.05
-  maxMonthlyCost: 40
+  # List-price basis: GKE Standard: mgmt fee 0.10 + 3x e2-medium @0.0335 (us-central1)
+  estimatedHourlyCost: 0.25
+  maxMonthlyCost: 180
   budgetAlertThreshold: 0.8
-  warningMessage: GKE Standard tier has no control plane cost. Only compute resources
-    are billed.
+  warningMessage: GKE Standard bills a $0.10/hr cluster management fee plus compute
+    for each node; the management fee continues even when node pools scale to zero.
 platformConfig:
   gcp:
     project: migration-eng

--- a/internal/profile/definitions/ibmcloud-minimal-test.yaml
+++ b/internal/profile/definitions/ibmcloud-minimal-test.yaml
@@ -61,8 +61,9 @@ features:
   fipsMode: false
   privateCluster: false
 costControls:
-  estimatedHourlyCost: 2.8
-  maxMonthlyCost: 2000
+  # List-price basis: ROKS: 3x bx2-4x16 @0.194 (0 workers) + infra (IBM list)
+  estimatedHourlyCost: 0.8
+  maxMonthlyCost: 580
   budgetAlertThreshold: 0.8
 platformConfig:
   ibmcloud:

--- a/internal/profile/definitions/ibmcloud-standard.yaml
+++ b/internal/profile/definitions/ibmcloud-standard.yaml
@@ -60,8 +60,9 @@ features:
   fipsMode: false
   privateCluster: false
 costControls:
-  estimatedHourlyCost: 8.5
-  maxMonthlyCost: 6100
+  # List-price basis: ROKS: 3x bx2-4x16 @0.194 + 3x bx2-8x32 @0.388 + infra (IBM list)
+  estimatedHourlyCost: 2.0
+  maxMonthlyCost: 1460
   budgetAlertThreshold: 0.8
 platformConfig:
   ibmcloud:

--- a/internal/profile/definitions/iks-minimal.yaml
+++ b/internal/profile/definitions/iks-minimal.yaml
@@ -66,8 +66,9 @@ features:
   publicServiceEndpoint: true
   privateServiceEndpoint: true
 costControls:
+  # List-price basis: IKS: 2x b3c.4x16 @0.114 + net (IBM list)
   estimatedHourlyCost: 0.28
-  maxMonthlyCost: 202
+  maxMonthlyCost: 200
   budgetAlertThreshold: 0.8
 platformConfig:
   ibmcloud:

--- a/internal/profile/definitions/iks-standard.yaml
+++ b/internal/profile/definitions/iks-standard.yaml
@@ -66,8 +66,9 @@ features:
   publicServiceEndpoint: true
   privateServiceEndpoint: true
 costControls:
-  estimatedHourlyCost: 1.12
-  maxMonthlyCost: 806
+  # List-price basis: IKS: 4x bx2.8x32 @0.388 + net (IBM list)
+  estimatedHourlyCost: 1.6
+  maxMonthlyCost: 1170
   budgetAlertThreshold: 0.8
 platformConfig:
   ibmcloud:

--- a/internal/profile/definitions/rosa-minimal.yaml
+++ b/internal/profile/definitions/rosa-minimal.yaml
@@ -66,8 +66,9 @@ features:
   fipsMode: false
   privateCluster: false
 costControls:
-  estimatedHourlyCost: 0.42
-  maxMonthlyCost: 310
+  # List-price basis: ROSA classic: 3x m5.2xlarge @0.384 + 2x m5.xlarge @0.192 + RH svc 0.171/4vCPU (us-east-1)
+  estimatedHourlyCost: 2.03
+  maxMonthlyCost: 1480
   budgetAlertThreshold: 0.8
 platformConfig:
   aws:

--- a/internal/profile/definitions/rosa-standard.yaml
+++ b/internal/profile/definitions/rosa-standard.yaml
@@ -67,8 +67,9 @@ features:
   fipsMode: false
   privateCluster: false
 costControls:
-  estimatedHourlyCost: 1.2
-  maxMonthlyCost: 900
+  # List-price basis: ROSA classic: 3x m5.2xlarge @0.384 + 3x m5.2xlarge @0.384 + RH svc 0.171/4vCPU (us-east-1)
+  estimatedHourlyCost: 3.53
+  maxMonthlyCost: 2580
   budgetAlertThreshold: 0.8
 platformConfig:
   aws:

--- a/internal/profile/gcp_profiles_test.go
+++ b/internal/profile/gcp_profiles_test.go
@@ -40,8 +40,8 @@ func TestGCPProfiles_Load(t *testing.T) {
 
 		// Verify cost controls
 		require.NotNil(t, prof.CostControls)
-		assert.Equal(t, 0.05, prof.CostControls.EstimatedHourlyCost)
-		assert.Contains(t, prof.CostControls.WarningMessage, "no control plane cost")
+		assert.Equal(t, 0.25, prof.CostControls.EstimatedHourlyCost)
+		assert.Contains(t, prof.CostControls.WarningMessage, "management fee")
 
 		// Verify lifecycle
 		assert.Equal(t, 168, prof.Lifecycle.MaxTTLHours)
@@ -101,7 +101,7 @@ func TestGCPProfiles_Load(t *testing.T) {
 
 		// Verify cost controls
 		require.NotNil(t, prof.CostControls)
-		assert.Equal(t, 1.20, prof.CostControls.EstimatedHourlyCost)
+		assert.Equal(t, 1.90, prof.CostControls.EstimatedHourlyCost)
 		assert.Contains(t, prof.CostControls.WarningMessage, "GCE VMs")
 
 		// Verify platform config
@@ -169,26 +169,26 @@ func TestGCPProfiles_CostEstimates(t *testing.T) {
 		prof, err := loader.Load("gke-standard")
 		require.NoError(t, err)
 
-		assert.Equal(t, 0.05, prof.CostControls.EstimatedHourlyCost)
-		assert.Equal(t, float64(40), prof.CostControls.MaxMonthlyCost)
+		assert.Equal(t, 0.25, prof.CostControls.EstimatedHourlyCost)
+		assert.Equal(t, float64(180), prof.CostControls.MaxMonthlyCost)
 
 		// Verify monthly cost calculation
 		hoursPerMonth := 24 * 30 // 720 hours
 		estimatedMonthlyCost := prof.CostControls.EstimatedHourlyCost * float64(hoursPerMonth)
-		assert.InDelta(t, 36.0, estimatedMonthlyCost, 5.0)
+		assert.InDelta(t, 180.0, estimatedMonthlyCost, 10.0)
 	})
 
 	t.Run("gcp-standard cost estimates", func(t *testing.T) {
 		prof, err := loader.Load("gcp-standard")
 		require.NoError(t, err)
 
-		assert.Equal(t, 1.20, prof.CostControls.EstimatedHourlyCost)
-		assert.Equal(t, float64(900), prof.CostControls.MaxMonthlyCost)
+		assert.Equal(t, 1.90, prof.CostControls.EstimatedHourlyCost)
+		assert.Equal(t, float64(1390), prof.CostControls.MaxMonthlyCost)
 
 		// Verify monthly cost calculation
 		hoursPerMonth := 24 * 30 // 720 hours
 		estimatedMonthlyCost := prof.CostControls.EstimatedHourlyCost * float64(hoursPerMonth)
-		assert.InDelta(t, 864.0, estimatedMonthlyCost, 50.0)
+		assert.InDelta(t, 1368.0, estimatedMonthlyCost, 50.0)
 	})
 }
 


### PR DESCRIPTION
## Summary
The usage/cost report multiplies runtime hours by each profile's `costControls.estimatedHourlyCost` — a flat, **hand-typed** scalar that was often badly off. This recomputes every profile's rate from a consistent, documented model so the report (and per-team costs page, which shares the same math) is meaningfully more accurate.

## Model
For each profile: `rate = Σ(control-plane + worker on-demand list prices) + managed-service fee + small infra overhead`, using us-east-1 / East US / us-central1 / IBM list prices (~2026-08).
- **EKS / GKE**: + $0.10/hr control-plane (GKE Standard management) fee.
- **ROSA classic**: + Red Hat $0.171 per 4 vCPU-hr on worker nodes (control-plane EC2 was previously ignored entirely).
- Every value now carries a one-line `# List-price basis:` derivation comment, and `maxMonthlyCost` is resynced to `hourly × 730`.

## Notable corrections
| Profile | Old $/hr | New $/hr |
|---|---|---|
| aws-standard(-ga/-prerelease) | 7.80 | 1.98 |
| ibmcloud-standard | 8.50 | 2.00 |
| aws-virtualization | 35.50 | 20.10 |
| aws-sno-ga | 0.80 | 0.48 |
| gke-standard | 0.05 | 0.25 |
| gcp-standard | 1.20 | 1.90 |
| iks-standard | 1.12 | 1.60 |
| rosa-standard | 1.20 | 3.53 |

(37 profiles updated in total.)

## GKE bug fixes
- **Hibernation:** hibernated GKE now bills the fixed **$0.10/hr management fee** (which persists when node pools scale to zero) instead of 3% of the base rate.
- **warningMessage:** corrected the profile note that wrongly claimed GKE Standard has no control-plane cost.

## Caveats
These are **list-price** estimates: no committed-use/spot discounts, and autoscaling worker counts are treated as nominal (`replicas`). True per-cluster actuals would require wiring cloud billing exports (out of scope here).

## Testing
- `go build ./...`, `go test ./...` — all green (updated the GCP profile + GKE hibernation assertions)
- All 37 profile YAMLs validated as parseable