### PR TITLE
Add most-used OpenShift versions and add-ons to usage report

### DIFF
--- a/internal/api/handler_reports.go
+++ b/internal/api/handler_reports.go
@@ -91,6 +91,8 @@ func (h *ReportHandler) GetUsageReport(c echo.Context) error {
 	// Aggregate cost / profiles / users over the window.
 	profileAgg := map[string]*types.ProfileUsage{}
 	userAgg := map[string]*types.UserUsage{}
+	versionAgg := map[string]*types.VersionUsage{}
+	addonAgg := map[string]*types.AddonUsage{}
 	var totalCost, totalHours float64
 	var lifetimeSum float64
 	var lifetimeCount int
@@ -149,6 +151,35 @@ func (h *ReportHandler) GetUsageReport(c echo.Context) error {
 		uu.RuntimeHours += clusterHours
 		uu.EstimatedCost += clusterCost
 
+		// Version aggregation — only for OpenShift-family clusters, which report an
+		// OpenShift version (openshift/rosa/aro). Other types carry Kubernetes
+		// versions and are excluded from the "OpenShift versions" breakdown.
+		if cl.Version != "" && isOpenShiftFamily(cl.ClusterType) {
+			vu := versionAgg[cl.Version]
+			if vu == nil {
+				vu = &types.VersionUsage{Version: cl.Version}
+				versionAgg[cl.Version] = vu
+			}
+			vu.ClusterCount++
+			vu.RuntimeHours += clusterHours
+			vu.EstimatedCost += clusterCost
+		}
+
+		// Addon aggregation — a cluster contributes to every addon it selected.
+		for _, addonID := range cl.SelectedAddonIDs {
+			if addonID == "" {
+				continue
+			}
+			au := addonAgg[addonID]
+			if au == nil {
+				au = &types.AddonUsage{Addon: addonID}
+				addonAgg[addonID] = au
+			}
+			au.ClusterCount++
+			au.RuntimeHours += clusterHours
+			au.EstimatedCost += clusterCost
+		}
+
 		// Average lifetime (over clusters active in-window). Cap still-running
 		// clusters at the current time, not the window end: the window end may be
 		// in the future (end-of-day today) or, for a past-dated range, long before
@@ -199,6 +230,29 @@ func (h *ReportHandler) GetUsageReport(c echo.Context) error {
 		return users[i].ClusterCount > users[j].ClusterCount
 	})
 
+	// Sort versions and addons by cluster count desc (tie-break on est. cost).
+	versions := make([]types.VersionUsage, 0, len(versionAgg))
+	for _, vu := range versionAgg {
+		versions = append(versions, *vu)
+	}
+	sort.Slice(versions, func(i, j int) bool {
+		if versions[i].ClusterCount != versions[j].ClusterCount {
+			return versions[i].ClusterCount > versions[j].ClusterCount
+		}
+		return versions[i].EstimatedCost > versions[j].EstimatedCost
+	})
+
+	addons := make([]types.AddonUsage, 0, len(addonAgg))
+	for _, au := range addonAgg {
+		addons = append(addons, *au)
+	}
+	sort.Slice(addons, func(i, j int) bool {
+		if addons[i].ClusterCount != addons[j].ClusterCount {
+			return addons[i].ClusterCount > addons[j].ClusterCount
+		}
+		return addons[i].EstimatedCost > addons[j].EstimatedCost
+	})
+
 	// Prior-period comparison: an equally-sized window immediately preceding the
 	// current one. Queried separately so the current-window aggregations above
 	// (counts, breakdowns) only ever reflect clusters active in-window.
@@ -236,10 +290,23 @@ func (h *ReportHandler) GetUsageReport(c echo.Context) error {
 		},
 		Profiles:  profiles,
 		Users:     users,
+		Versions:  versions,
+		Addons:    addons,
 		Lifecycle: lifecycle,
 	}
 
 	return SuccessOK(c, report)
+}
+
+// isOpenShiftFamily reports whether a cluster type carries an OpenShift version
+// (as opposed to a plain Kubernetes version).
+func isOpenShiftFamily(t types.ClusterType) bool {
+	switch t {
+	case types.ClusterTypeOpenShift, types.ClusterTypeROSA, types.ClusterTypeARO:
+		return true
+	default:
+		return false
+	}
 }
 
 // sumWindowCost returns the total estimated cost for the given clusters over the

--- a/internal/store/report.go
+++ b/internal/store/report.go
@@ -28,8 +28,9 @@ type ReportStore struct {
 // Cluster struct is left zero-valued.
 func (s *ReportStore) GetClustersActiveInRange(ctx context.Context, start, end time.Time) ([]*types.Cluster, error) {
 	query := `
-		SELECT id, name, platform, cluster_type, profile, region,
-			owner, owner_id, team, status, created_at, destroyed_at
+		SELECT id, name, platform, cluster_type, version, profile, region,
+			owner, owner_id, team, status, created_at, destroyed_at,
+			selected_addon_ids
 		FROM clusters
 		WHERE created_at <= $2
 		  AND (
@@ -53,6 +54,7 @@ func (s *ReportStore) GetClustersActiveInRange(ctx context.Context, start, end t
 			&c.Name,
 			&c.Platform,
 			&c.ClusterType,
+			&c.Version,
 			&c.Profile,
 			&c.Region,
 			&c.Owner,
@@ -61,6 +63,7 @@ func (s *ReportStore) GetClustersActiveInRange(ctx context.Context, start, end t
 			&c.Status,
 			&c.CreatedAt,
 			&c.DestroyedAt,
+			&c.SelectedAddonIDs,
 		); err != nil {
 			return nil, fmt.Errorf("scan cluster: %w", err)
 		}

--- a/pkg/types/report.go
+++ b/pkg/types/report.go
@@ -13,6 +13,8 @@ type UsageReport struct {
 	Cost      UsageCostSummary `json:"cost"`
 	Profiles  []ProfileUsage   `json:"profiles"` // sorted by cluster count desc
 	Users     []UserUsage      `json:"users"`    // sorted by est. cost desc
+	Versions  []VersionUsage   `json:"versions"` // OpenShift-family versions, sorted by cluster count desc
+	Addons    []AddonUsage     `json:"addons"`   // sorted by cluster count desc
 	Lifecycle LifecycleStats   `json:"lifecycle"`
 }
 
@@ -51,6 +53,26 @@ type ClusterUsage struct {
 // UserUsage aggregates usage for a single owner within the window.
 type UserUsage struct {
 	Owner         string  `json:"owner"` // email when resolvable, else owner_id
+	ClusterCount  int     `json:"cluster_count"`
+	RuntimeHours  float64 `json:"runtime_hours"`
+	EstimatedCost float64 `json:"estimated_cost"`
+}
+
+// VersionUsage aggregates usage for a single OpenShift-family version within the
+// window. Only clusters whose type is openshift/rosa/aro (i.e. that report an
+// OpenShift version rather than a plain Kubernetes version) are counted.
+type VersionUsage struct {
+	Version       string  `json:"version"`
+	ClusterCount  int     `json:"cluster_count"`
+	RuntimeHours  float64 `json:"runtime_hours"`
+	EstimatedCost float64 `json:"estimated_cost"`
+}
+
+// AddonUsage aggregates usage for a single addon within the window. A cluster
+// contributes to every addon it selected, so ClusterCount is "clusters that use
+// this addon" and the runtime/cost figures are that set's combined footprint.
+type AddonUsage struct {
+	Addon         string  `json:"addon"`
 	ClusterCount  int     `json:"cluster_count"`
 	RuntimeHours  float64 `json:"runtime_hours"`
 	EstimatedCost float64 `json:"estimated_cost"`

--- a/web/app/(dashboard)/admin/usage-report/page.tsx
+++ b/web/app/(dashboard)/admin/usage-report/page.tsx
@@ -37,6 +37,14 @@ const usersChartConfig = {
   estimated_cost: { label: "Est. cost", color: "hsl(var(--chart-2))" },
 } satisfies ChartConfig;
 
+const versionsChartConfig = {
+  cluster_count: { label: "Clusters", color: "hsl(var(--chart-3))" },
+} satisfies ChartConfig;
+
+const addonsChartConfig = {
+  cluster_count: { label: "Clusters", color: "hsl(var(--chart-4))" },
+} satisfies ChartConfig;
+
 type Preset = { label: string; range: () => [string, string] };
 
 const PRESETS: Preset[] = [
@@ -258,6 +266,94 @@ export default function UsageReportPage() {
             </CardContent>
           </Card>
 
+          {/* Most used OpenShift versions */}
+          <Card>
+            <CardHeader>
+              <CardTitle>Most Used OpenShift Versions</CardTitle>
+              <CardDescription>
+                OpenShift, ROSA, and ARO clusters ranked by cluster count over the selected range
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-6">
+              {report.versions.length > 0 ? (
+                <>
+                  <ChartContainer config={versionsChartConfig} className="h-64 w-full">
+                    <BarChart
+                      accessibilityLayer
+                      data={report.versions.slice(0, 10)}
+                      layout="vertical"
+                      margin={{ left: 12, right: 16 }}
+                    >
+                      <CartesianGrid horizontal={false} />
+                      <XAxis type="number" dataKey="cluster_count" allowDecimals={false} tickLine={false} axisLine={false} />
+                      <YAxis
+                        type="category"
+                        dataKey="version"
+                        tickLine={false}
+                        axisLine={false}
+                        width={150}
+                        tickFormatter={(v: string) => (v.length > 22 ? `${v.slice(0, 21)}…` : v)}
+                      />
+                      <ChartTooltip cursor={false} content={<ChartTooltipContent />} />
+                      <Bar dataKey="cluster_count" fill="var(--color-cluster_count)" radius={[0, 4, 4, 0]} />
+                    </BarChart>
+                  </ChartContainer>
+                  <UsageTable
+                    rows={report.versions}
+                    nameHeader="Version"
+                    nameKey="version"
+                    emptyText="No OpenShift clusters in range"
+                  />
+                </>
+              ) : (
+                <p className="text-sm text-muted-foreground">No OpenShift clusters in range</p>
+              )}
+            </CardContent>
+          </Card>
+
+          {/* Most used add-ons */}
+          <Card>
+            <CardHeader>
+              <CardTitle>Most Used Add-ons</CardTitle>
+              <CardDescription>Ranked by number of clusters using each add-on over the selected range</CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-6">
+              {report.addons.length > 0 ? (
+                <>
+                  <ChartContainer config={addonsChartConfig} className="h-64 w-full">
+                    <BarChart
+                      accessibilityLayer
+                      data={report.addons.slice(0, 10)}
+                      layout="vertical"
+                      margin={{ left: 12, right: 16 }}
+                    >
+                      <CartesianGrid horizontal={false} />
+                      <XAxis type="number" dataKey="cluster_count" allowDecimals={false} tickLine={false} axisLine={false} />
+                      <YAxis
+                        type="category"
+                        dataKey="addon"
+                        tickLine={false}
+                        axisLine={false}
+                        width={150}
+                        tickFormatter={(v: string) => (v.length > 22 ? `${v.slice(0, 21)}…` : v)}
+                      />
+                      <ChartTooltip cursor={false} content={<ChartTooltipContent />} />
+                      <Bar dataKey="cluster_count" fill="var(--color-cluster_count)" radius={[0, 4, 4, 0]} />
+                    </BarChart>
+                  </ChartContainer>
+                  <UsageTable
+                    rows={report.addons}
+                    nameHeader="Add-on"
+                    nameKey="addon"
+                    emptyText="No add-ons in range"
+                  />
+                </>
+              ) : (
+                <p className="text-sm text-muted-foreground">No add-ons in range</p>
+              )}
+            </CardContent>
+          </Card>
+
           {/* Lifecycle breakdowns */}
           <div className="grid gap-4 md:grid-cols-3">
             <BreakdownCard title="By Platform" data={report.lifecycle.by_platform} />
@@ -299,12 +395,14 @@ function UsageTable({
   rows: Array<{
     profile?: string;
     owner?: string;
+    version?: string;
+    addon?: string;
     cluster_count: number;
     runtime_hours: number;
     estimated_cost: number;
   }>;
   nameHeader: string;
-  nameKey: "profile" | "owner";
+  nameKey: "profile" | "owner" | "version" | "addon";
   emptyText: string;
 }) {
   if (rows.length === 0) {

--- a/web/lib/api/endpoints/reports.ts
+++ b/web/lib/api/endpoints/reports.ts
@@ -42,6 +42,20 @@ export interface UserUsage {
   estimated_cost: number;
 }
 
+export interface VersionUsage {
+  version: string;
+  cluster_count: number;
+  runtime_hours: number;
+  estimated_cost: number;
+}
+
+export interface AddonUsage {
+  addon: string;
+  cluster_count: number;
+  runtime_hours: number;
+  estimated_cost: number;
+}
+
 export interface LifecycleStats {
   created: number;
   destroyed: number;
@@ -62,6 +76,8 @@ export interface UsageReport {
   cost: UsageCostSummary;
   profiles: ProfileUsage[];
   users: UserUsage[];
+  versions: VersionUsage[];
+  addons: AddonUsage[];
   lifecycle: LifecycleStats;
 }
 

--- a/web/lib/reports/exportPdf.ts
+++ b/web/lib/reports/exportPdf.ts
@@ -116,6 +116,36 @@ export function exportUsageReportPdf(report: UsageReport) {
     margin: { left: marginX, right: marginX },
   });
 
+  // Most used OpenShift versions
+  autoTable(doc, {
+    startY: (doc as any).lastAutoTable.finalY + 20,
+    head: [["Most Used OpenShift Versions", "Clusters", "Runtime hrs", "Est. cost"]],
+    body: report.versions.map((v) => [
+      v.version,
+      String(v.cluster_count),
+      v.runtime_hours.toFixed(1),
+      formatCurrency(v.estimated_cost),
+    ]),
+    theme: "striped",
+    headStyles: { fillColor: [30, 41, 59] },
+    margin: { left: marginX, right: marginX },
+  });
+
+  // Most used add-ons
+  autoTable(doc, {
+    startY: (doc as any).lastAutoTable.finalY + 20,
+    head: [["Most Used Add-ons", "Clusters", "Runtime hrs", "Est. cost"]],
+    body: report.addons.map((a) => [
+      a.addon,
+      String(a.cluster_count),
+      a.runtime_hours.toFixed(1),
+      formatCurrency(a.estimated_cost),
+    ]),
+    theme: "striped",
+    headStyles: { fillColor: [30, 41, 59] },
+    margin: { left: marginX, right: marginX },
+  });
+
   // Breakdowns
   const breakdownRows = (m: Record<string, number>) =>
     Object.entries(m)


### PR DESCRIPTION
## Summary
Adds two new sections to the admin Usage Report, alongside **Most Used Profiles** and **Most Active Users**:

- **Most Used OpenShift Versions** — clusters of type `openshift`/`rosa`/`aro` aggregated by version (other types carry Kubernetes versions and are excluded). Ranked by cluster count, with runtime hours and est. cost.
- **Most Used Add-ons** — aggregated over each cluster's `selected_addon_ids`, so a cluster contributes to every add-on it uses. Ranked by cluster count.

## Changes
- **Backend:** `GetClustersActiveInRange` now selects `version` + `selected_addon_ids`; the handler folds them into two new aggregates (`VersionUsage`, `AddonUsage`) sorted by cluster count. New `isOpenShiftFamily` helper scopes the version breakdown.
- **Frontend:** two new cards, each a horizontal Recharts bar chart + table; `UsageTable` generalized to accept `version`/`addon` keys.
- **PDF export:** matching autotable sections.

## Verification
- `go build ./...` + `go test ./internal/api/ ./internal/store/` pass.
- `tsc --noEmit` clean; `npm run build` succeeds.
- Deployed to dev (`v0.20260823.3649247`) for review.